### PR TITLE
Flexibe datainput

### DIFF
--- a/simson/common/custom_data_reader.py
+++ b/simson/common/custom_data_reader.py
@@ -2,7 +2,7 @@ import logging
 import os
 from typing import List
 
-from sodym.data_reader import CompoundDataReader, CSVDimensionReader, CSVParameterReader, YamlScalarDataReader, EmptyScalarDataReader
+from sodym.data_reader import CompoundDataReader, CSVDimensionReader, CSVParameterReader
 from sodym.mfa_definition import MFADefinition
 
 
@@ -17,7 +17,7 @@ class CustomDataReader(CompoundDataReader):
         'Intermediate': 'intermediate_products',
         'Scenario': 'scenarios',
     }
-    def __init__(self, input_data_path, definition: MFADefinition, has_scalar_parameters: bool):
+    def __init__(self, input_data_path, definition: MFADefinition):
         self.input_data_path = input_data_path
 
         dimension_files = {}
@@ -35,10 +35,4 @@ class CustomDataReader(CompoundDataReader):
             )
         parameter_reader = CSVParameterReader(parameter_files)
 
-        if has_scalar_parameters:
-            scalar_data_yaml = os.path.join(input_data_path, 'scalar_parameters.yml')
-        else:
-            scalar_data_yaml = None
-        scalar_data_reader = YamlScalarDataReader(scalar_data_yaml)
-
-        super().__init__(dimension_reader=dimension_reader, parameter_reader=parameter_reader, scalar_data_reader=scalar_data_reader)
+        super().__init__(dimension_reader=dimension_reader, parameter_reader=parameter_reader)

--- a/simson/common/custom_data_reader.py
+++ b/simson/common/custom_data_reader.py
@@ -2,11 +2,11 @@ import logging
 import os
 from typing import List
 
-from sodym.data_reader import ExampleDataReader
-from sodym import DimensionDefinition
+from sodym.data_reader import CompoundDataReader, CSVDimensionReader, CSVParameterReader, YamlScalarDataReader, EmptyScalarDataReader
+from sodym.mfa_definition import MFADefinition
 
 
-class CustomDataReader(ExampleDataReader):
+class CustomDataReader(CompoundDataReader):
     dimension_map = {
         'Time': 'time_in_years',
         'Historic Time': 'historic_years',
@@ -17,27 +17,28 @@ class CustomDataReader(ExampleDataReader):
         'Intermediate': 'intermediate_products',
         'Scenario': 'scenarios',
     }
-    def __init__(self, input_data_path):
+    def __init__(self, input_data_path, definition: MFADefinition, has_scalar_parameters: bool):
         self.input_data_path = input_data_path
-        scalar_data_yaml = os.path.join(input_data_path, 'scalar_parameters.yml')
-        super().__init__(scalar_data_yaml, {}, {})
 
-    def read_parameter_values(self, parameter: str, dims):
-        self.parameter_datasets[parameter] = os.path.join(
-            self.input_data_path, 'datasets', f'{parameter}.csv'
-        )
-        return super().read_parameter_values(parameter=parameter, dims=dims)
+        dimension_files = {}
+        for dimension in definition.dimensions:
+            dimension_filename = self.dimension_map[dimension.name]
+            dimension_files[dimension.name] = os.path.join(
+                self.input_data_path, 'dimensions', f'{dimension_filename}.csv'
+            )
+        dimension_reader = CSVDimensionReader(dimension_files)
 
-    def read_dimension(self, definition: DimensionDefinition):
-        dimension_filename = self.dimension_map[definition.name]
-        self.dimension_datasets[definition.name] = os.path.join(
-            self.input_data_path, 'dimensions', f'{dimension_filename}.csv'
-        )
-        return super().read_dimension(definition=definition)
+        parameter_files = {}
+        for parameter in definition.parameters:
+            parameter_files[parameter.name] = os.path.join(
+                self.input_data_path, 'datasets', f'{parameter.name}.csv'
+            )
+        parameter_reader = CSVParameterReader(parameter_files)
 
-    def read_scalar_data(self, parameters: List[str]):
-        try:
-            return super().read_scalar_data(parameters)
-        except FileNotFoundError as file_missing:
-            logging.warn(file_missing)
-            return None
+        if has_scalar_parameters:
+            scalar_data_yaml = os.path.join(input_data_path, 'scalar_parameters.yml')
+        else:
+            scalar_data_yaml = None
+        scalar_data_reader = YamlScalarDataReader(scalar_data_yaml)
+
+        super().__init__(dimension_reader=dimension_reader, parameter_reader=parameter_reader, scalar_data_reader=scalar_data_reader)

--- a/simson/plastics/plastics_model.py
+++ b/simson/plastics/plastics_model.py
@@ -18,7 +18,7 @@ class PlasticsModel:
     def __init__(self, cfg: CommonCfg):
         self.cfg = cfg
         self.definition = self.set_up_definition()
-        self.data_reader = CustomDataReader(input_data_path=self.cfg.input_data_path)
+        self.data_reader = CustomDataReader(input_data_path=self.cfg.input_data_path, definition=self.definition, has_scalar_parameters=False)
         self.data_writer = CustomDataExporter(
             **dict(self.cfg.visualization), output_path=self.cfg.output_path,
             display_names=self.display_names

--- a/simson/plastics/plastics_model.py
+++ b/simson/plastics/plastics_model.py
@@ -18,7 +18,7 @@ class PlasticsModel:
     def __init__(self, cfg: CommonCfg):
         self.cfg = cfg
         self.definition = self.set_up_definition()
-        self.data_reader = CustomDataReader(input_data_path=self.cfg.input_data_path, definition=self.definition, has_scalar_parameters=False)
+        self.data_reader = CustomDataReader(input_data_path=self.cfg.input_data_path, definition=self.definition)
         self.data_writer = CustomDataExporter(
             **dict(self.cfg.visualization), output_path=self.cfg.output_path,
             display_names=self.display_names
@@ -26,7 +26,6 @@ class PlasticsModel:
 
         self.dims = self.data_reader.read_dimensions(self.definition.dimensions)
         self.parameters = self.data_reader.read_parameters(self.definition.parameters, dims=self.dims)
-        self.scalar_parameters = self.data_reader.read_scalar_data(self.definition.scalar_parameters)
         self.processes = {
             name: Process(name=name, id=id) for id, name in enumerate(self.definition.processes)
         }
@@ -51,7 +50,6 @@ class PlasticsModel:
         )
         return InflowDrivenHistoricMFA(
             parameters=self.parameters,
-            scalar_parameters=self.scalar_parameters,
             processes={'use': self.processes['use']},
             dims=historic_dims,
             flows={},
@@ -72,7 +70,7 @@ class PlasticsModel:
         )
         stocks['in_use'] = future_in_use_stock
         return PlasticsMFASystem(
-            dims=future_dims, parameters=self.parameters, scalar_parameters=self.scalar_parameters,
+            dims=future_dims, parameters=self.parameters,
             processes=self.processes, flows=flows, stocks=stocks,
         )
 

--- a/simson/steel/steel_model.py
+++ b/simson/steel/steel_model.py
@@ -18,7 +18,7 @@ class SteelModel:
     def __init__(self, cfg: CommonCfg):
         self.cfg = cfg
         self.definition = self.set_up_definition()
-        self.data_reader = CustomDataReader(input_data_path=self.cfg.input_data_path)
+        self.data_reader = CustomDataReader(input_data_path=self.cfg.input_data_path, definition=self.definition, has_scalar_parameters=True)
         self.data_writer = CustomDataExporter(
             **dict(self.cfg.visualization), output_path=self.cfg.output_path,
             display_names=self.display_names

--- a/simson/steel/steel_model.py
+++ b/simson/steel/steel_model.py
@@ -18,7 +18,7 @@ class SteelModel:
     def __init__(self, cfg: CommonCfg):
         self.cfg = cfg
         self.definition = self.set_up_definition()
-        self.data_reader = CustomDataReader(input_data_path=self.cfg.input_data_path, definition=self.definition, has_scalar_parameters=True)
+        self.data_reader = CustomDataReader(input_data_path=self.cfg.input_data_path, definition=self.definition)
         self.data_writer = CustomDataExporter(
             **dict(self.cfg.visualization), output_path=self.cfg.output_path,
             display_names=self.display_names
@@ -31,7 +31,6 @@ class SteelModel:
         # direct is for intermediate steel products, indirect for finished products like cars)
         # loading steel sector splits for intermediate products, and indirect trade
         self.parameters = self.data_reader.read_parameters(self.definition.parameters, dims=self.dims)
-        self.scalar_parameters = self.data_reader.read_scalar_data(self.definition.scalar_parameters)
 
         self.processes = {
             name: Process(name=name, id=id) for id, name in enumerate(self.definition.processes)
@@ -87,7 +86,6 @@ class SteelModel:
         return InflowDrivenHistoricSteelMFASystem(
             cfg=self.cfg,
             parameters=self.parameters,
-            scalar_parameters=self.scalar_parameters,
             processes=processes,
             dims=historic_dims,
             flows=flows,
@@ -189,7 +187,7 @@ class SteelModel:
         )
         stocks['use'] = future_in_use_stock
         return StockDrivenSteelMFASystem(
-            dims=future_dims, parameters=self.parameters, scalar_parameters=self.scalar_parameters,
+            dims=future_dims, parameters=self.parameters,
             processes=self.processes, flows=flows, stocks=stocks
         )
 
@@ -314,9 +312,12 @@ class SteelModel:
             ParameterDefinition(name='gdppc', dim_letters=('t', 'r')),
             ParameterDefinition(name='lifetime_mean', dim_letters=('r', 'g')),
             ParameterDefinition(name='lifetime_std', dim_letters=('r', 'g')),
-        ]
 
-        scalar_parameters = ['max_scrap_share_base_model','scrap_in_bof_rate','forming_losses','production_yield']
+            ParameterDefinition(name='max_scrap_share_base_model', dim_letters=()),
+            ParameterDefinition(name='scrap_in_bof_rate', dim_letters=()),
+            ParameterDefinition(name='forming_losses', dim_letters=()),
+            ParameterDefinition(name='production_yield', dim_letters=()),
+        ]
 
         return MFADefinition(
             dimensions=dimensions,
@@ -324,5 +325,4 @@ class SteelModel:
             flows=flows,
             stocks=stocks,
             parameters=parameters,
-            scalar_parameters=scalar_parameters,
         )

--- a/simson/steel/stock_driven_steel.py
+++ b/simson/steel/stock_driven_steel.py
@@ -16,7 +16,6 @@ class StockDrivenSteelMFASystem(MFASystem):
         prm = self.parameters
         flw = self.flows
         stk = self.stocks
-        scp = self.scalar_parameters
 
         # auxiliary arrays;
         # It is important to initialize them to define their dimensions. See the NamedDimArray documentation for details.
@@ -61,7 +60,7 @@ class StockDrivenSteelMFASystem(MFASystem):
         flw['forming => ip_market'][...]                = flw['ip_market => fabrication']       -   aux['net_direct_trade']
         aux['production'][...]                          = flw['forming => ip_market']           /   prm['forming_yield']
         aux['forming_outflow'][...]                     = aux['production']                     -   flw['forming => ip_market']
-        flw['forming => sysenv'][...]                   = aux['forming_outflow']                *   scp['forming_losses']
+        flw['forming => sysenv'][...]                   = aux['forming_outflow']                *   prm['forming_losses']
         flw['forming => scrap_market'][...]             = aux['forming_outflow']                -   flw['forming => sysenv']
 
         # Post-use
@@ -79,23 +78,23 @@ class StockDrivenSteelMFASystem(MFASystem):
 
         # PRODUCTION
 
-        aux['production_inflow'][...]                   = aux['production']                     /   scp['production_yield']
-        aux['max_scrap_production'][...]                = aux['production_inflow']              *   scp['max_scrap_share_base_model']
+        aux['production_inflow'][...]                   = aux['production']                     /   prm['production_yield']
+        aux['max_scrap_production'][...]                = aux['production_inflow']              *   prm['max_scrap_share_base_model']
         aux['available_scrap'][...]                     = flw['recycling => scrap_market']      +   flw['forming => scrap_market']          +   flw['fabrication => scrap_market']
         aux['scrap_in_production'][...]                 = aux['available_scrap'].minimum(aux['max_scrap_production'])  # using NumPy Minimum functionality
         flw['scrap_market => excess_scrap'][...]        = aux['available_scrap']                -   aux['scrap_in_production']
         #  TODO include copper like this:aux['scrap_share_production']['Fe'][...]        = aux['scrap_in_production']['Fe']      /   aux['production_inflow']['Fe']
         aux['scrap_share_production'][...]              = aux['scrap_in_production']            /   aux['production_inflow']
-        aux['eaf_share_production'][...]                = aux['scrap_share_production']         -   scp['scrap_in_bof_rate']
-        aux['eaf_share_production'][...]                = aux['eaf_share_production']           /   (1 - scp['scrap_in_bof_rate'])
+        aux['eaf_share_production'][...]                = aux['scrap_share_production']         -   prm['scrap_in_bof_rate'].cast_to(aux['scrap_share_production'].dims)
+        aux['eaf_share_production'][...]                = aux['eaf_share_production']           /   (1 - prm['scrap_in_bof_rate'])
         aux['eaf_share_production'][...]                = aux['eaf_share_production'].minimum(1).maximum(0)
         flw['scrap_market => eaf_production'][...]      = aux['production_inflow']              *   aux['eaf_share_production']
         flw['scrap_market => bof_production'][...]      = aux['scrap_in_production']            -   flw['scrap_market => eaf_production']
         aux['bof_production_inflow'][...]               = aux['production_inflow']              -   flw['scrap_market => eaf_production']
         flw['sysenv => bof_production'][...]            = aux['bof_production_inflow']          -   flw['scrap_market => bof_production']
-        flw['bof_production => forming'][...]           = aux['bof_production_inflow']          *   scp['production_yield']
+        flw['bof_production => forming'][...]           = aux['bof_production_inflow']          *   prm['production_yield']
         flw['bof_production => sysenv'][...]            = aux['bof_production_inflow']          -   flw['bof_production => forming']
-        flw['eaf_production => forming'][...]           = flw['scrap_market => eaf_production'] *   scp['production_yield']
+        flw['eaf_production => forming'][...]           = flw['scrap_market => eaf_production'] *   prm['production_yield']
         flw['eaf_production => sysenv'][...]            = flw['scrap_market => eaf_production'] -   flw['eaf_production => forming']
 
         return


### PR DESCRIPTION
Adaptations to sodym updates to data input. 

Scalar data input is removed, instead 0D-NamedDimArrays are enabled. 

This required a hotfix in `steel/compute_flows`, which will be unnecessary once intensive and extensive quantities are distinguished. 

(The 0d-array just made a design error in NamedDimArray apparent that already existed before, namely that the set intersection for addition/subtraction of two arrays is the correct behaviour for flows, but not for parameters) 