### PR TITLE
Refactor Extrapolation

### DIFF
--- a/config/plastics.yml
+++ b/config/plastics.yml
@@ -6,7 +6,7 @@ input_data_path: 'data/plastics/input'
 
 # model customization
 customization:
-  curve_strategy: 'GDP_regression'
+  curve_strategy: 'PehlExtrapolation'
   ldf_type: 'Normal'
 
 # visualization

--- a/config/steel.yml
+++ b/config/steel.yml
@@ -6,7 +6,7 @@ input_data_path: '../simson_data/data/steel/output'
 
 # model customization
 customization:
-  curve_strategy: 'Exponential_GDP_regression'
+  curve_strategy: 'ExponentialSaturationExtrapolation'
   ldf_type: 'LogNormal'
 
 # visualization

--- a/simson/common/data_extrapolations.py
+++ b/simson/common/data_extrapolations.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import ClassVar 
+from typing import ClassVar
 import numpy as np
 import sys
 from simson.common.base_model import SimsonBaseModel
@@ -23,9 +23,10 @@ class Extrapolation(SimsonBaseModel):
             regression[: self.n_historic] = self.data_to_extrapolate
         return regression
 
+
 class OneDimensionalExtrapolation(Extrapolation):
 
-    n_prms: ClassVar[int] = 2 # should be overwritten by subclasses if not 2
+    n_prms: ClassVar[int] = 2  # should be overwritten by subclasses if not 2
 
     @model_validator(mode="after")
     def validate_data(self):
@@ -35,11 +36,11 @@ class OneDimensionalExtrapolation(Extrapolation):
             self.data_to_extrapolate.shape[0] < self.target_range.shape[0]
         ), "data_to_extrapolate must be smaller then target_range"
         return self
-    
+
     @abstractmethod
     def func(x, prms):
         pass
-    
+
     @abstractmethod
     def initial_guess(self):
         pass
@@ -49,7 +50,9 @@ class OneDimensionalExtrapolation(Extrapolation):
         return f - self.data_to_extrapolate
 
     def regress(self):
-        self.fit_prms = least_squares(self.fitting_function, x0=self.initial_guess(), gtol=1.0e-12).x
+        self.fit_prms = least_squares(
+            self.fitting_function, x0=self.initial_guess(), gtol=1.0e-12
+        ).x
         regression = self.func(self.target_range, self.fit_prms)
         return regression
 

--- a/simson/common/data_transformations.py
+++ b/simson/common/data_transformations.py
@@ -1,61 +1,104 @@
 import numpy as np
 import flodym as fd
 from typing import Union
+from typing import Callable
+
 
 from .data_extrapolations import (
+    OneDimensionalExtrapolation,
     SigmoidalExtrapolation,
     ExponentialExtrapolation,
     WeightedProportionalExtrapolation,
 )
 
+class StockExtrapolation:
 
-def extrapolate_stock(
-    historic_stocks: fd.StockArray,
-    dims: fd.DimensionSet,
-    parameters: dict[str, fd.Parameter],
-    curve_strategy: str,
-    target_dim_letters=None,
-):
-    """Performs the per-capita transformation and the extrapolation."""
+    def __init__(
+            self, 
+            historic_stocks: fd.StockArray, 
+            dims: fd.DimensionSet, 
+            parameters: dict[str, fd.Parameter], 
+            curve_strategy: str, 
+            target_dim_letters=None
+        ):
+        self.historic_stocks = historic_stocks
+        self.dims = dims
+        self.parameters = parameters
+        self.curve_strategy = curve_strategy
+        self.target_dim_letters = target_dim_letters
+        self.find_regression_strategy()
+        self.find_extrapolation_class()
+        self.n_fit_prms = self.extrapolation_class.n_prms()
+        self.extrapolate()
 
-    if target_dim_letters is None:
-        historic_dim_letters = historic_stocks.dims.letters
-        target_dim_letters = ("t",) + historic_dim_letters[1:]
-    else:
-        historic_dim_letters = ("h",) + target_dim_letters[1:]
+    def find_regression_strategy(self) -> Callable:
+        """For now, only a regression based on GDP is implemented."""
+        self.regression_strategy = self.gdp_regression
+        
+    def find_extrapolation_class(self) -> OneDimensionalExtrapolation:
+        if self.curve_strategy == "GDP_regression":
+            self.extrapolation_class = SigmoidalExtrapolation
+        elif self.curve_strategy == "Exponential_GDP_regression":
+            self.extrapolation_class = ExponentialExtrapolation
+        else:
+            raise ValueError('fitting_function_type must be either "sigmoid" or "exponential".')
+    
+    def extrapolate(self):
+        self.per_capita_transformation()
+        self.regression_strategy()
 
-    # transform to per capita
-    pop = parameters["population"]
-    historic_pop = fd.FlodymArray(dims=dims[("h", "r")])
-    historic_gdppc = fd.FlodymArray(dims=dims[("h", "r")])
-    historic_stocks_pc = fd.FlodymArray(dims=dims[historic_dim_letters])
-    stocks_pc = fd.FlodymArray(dims=dims[target_dim_letters])
-    stocks = fd.FlodymArray(dims=dims[target_dim_letters])
+    def per_capita_transformation(self):
+        if self.target_dim_letters is None:
+            self.historic_dim_letters = self.historic_stocks.dims.letters
+            self.target_dim_letters = ("t",) + self.historic_dim_letters[1:]
+        else:
+            self.historic_dim_letters = ("h",) + self.target_dim_letters[1:]
 
-    historic_pop[...] = pop[{"t": dims["h"]}]
-    historic_gdppc[...] = parameters["gdppc"][{"t": dims["h"]}]
-    historic_stocks_pc[...] = historic_stocks / historic_pop
+        # transform to per capita
+        self.pop = self.parameters["population"]
+        self.gdppc = self.parameters["gdppc"]
+        self.historic_pop = fd.FlodymArray(dims=self.dims[("h", "r")])
+        self.historic_gdppc = fd.FlodymArray(dims=self.dims[("h", "r")])
+        self.historic_stocks_pc = fd.FlodymArray(dims=self.dims[self.historic_dim_letters])
+        self.stocks_pc = fd.FlodymArray(dims=self.dims[self.target_dim_letters])
+        self.stocks = fd.FlodymArray(dims=self.dims[self.target_dim_letters])
 
-    if curve_strategy == "GDP_regression":
-        gdp_regression(historic_stocks_pc.values, parameters["gdppc"].values, stocks_pc.values)
-    elif curve_strategy == "Exponential_GDP_regression":
-        gdp_regression(
-            historic_stocks_pc.values,
-            parameters["gdppc"].values,
-            stocks_pc.values,
-            fitting_function_type="exponential",
+        self.historic_pop[...] = self.pop[{"t": self.dims["h"]}]
+        self.historic_gdppc[...] = self.gdppc[{"t": self.dims["h"]}]
+        self.historic_stocks_pc[...] = self.historic_stocks / self.historic_pop
+
+    def gdp_regression(self):
+        """Updates per capita stock to future by extrapolation."""
+        prediction_out = self.stocks_pc.values
+        historic_in = self.historic_stocks_pc.values
+        shape_out = prediction_out.shape
+        pure_prediction = np.zeros_like(prediction_out)
+        n_historic = historic_in.shape[0]
+        self.fit_prms = np.zeros(shape_out[1:] + (self.n_fit_prms,))
+
+        for idx in np.ndindex(shape_out[1:]):
+            # idx is a tuple of indices for all dimensions except the time dimension
+            index = (slice(None),) + idx
+            current_hist_stock_pc = historic_in[index]
+            current_gdppc = self.gdppc.values[index[:2]]
+            extrapolation = self.extrapolation_class(
+                data_to_extrapolate=current_hist_stock_pc, target_range=current_gdppc
+            )
+            pure_prediction[index] = extrapolation.regress()
+            self.fit_prms[idx] = extrapolation.fit_prms
+
+        prediction_out[...] = pure_prediction - (
+            pure_prediction[n_historic - 1, :] - historic_in[n_historic - 1, :]
         )
-    else:
-        raise RuntimeError(
-            f"Extrapolation strategy {curve_strategy} is not defined. "
-            f"It needs to be 'GDP_regression'."
-        )
+        prediction_out[:n_historic, ...] = historic_in
 
-    # transform back to total stocks
-    stocks[...] = stocks_pc * pop
+        # transform back to total stocks
+        self.stocks[...] = self.stocks_pc * self.pop
+        self.transform_to_fd_stock_array()
 
-    # visualize_stock(self, self.parameters['gdppc'], historic_gdppc, stocks, historic_stocks, stocks_pc, historic_stocks_pc)
-    return fd.StockArray(**dict(stocks))
+    def transform_to_fd_stock_array(self):
+        self.stocks = fd.StockArray(**dict(self.stocks))
+        self.stocks_pc = fd.StockArray(**dict(self.stocks_pc))
 
 
 def extrapolate_to_future(
@@ -83,31 +126,3 @@ def extrapolate_to_future(
     extrapolated_values.set_values(extrapolation.extrapolate())
 
     return extrapolated_values
-
-
-def gdp_regression(historic_stocks_pc, gdppc, prediction_out, fitting_function_type="sigmoid"):
-    shape_out = prediction_out.shape
-    pure_prediction = np.zeros_like(prediction_out)
-    n_historic = historic_stocks_pc.shape[0]
-
-    if fitting_function_type == "sigmoid":
-        extrapolation_class = SigmoidalExtrapolation
-    elif fitting_function_type == "exponential":
-        extrapolation_class = ExponentialExtrapolation
-    else:
-        raise ValueError('fitting_function_type must be either "sigmoid" or "exponential".')
-
-    for idx in np.ndindex(shape_out[1:]):
-        # idx is a tuple of indices for all dimensions except the time dimension
-        index = (slice(None),) + idx
-        current_hist_stock_pc = historic_stocks_pc[index]
-        current_gdppc = gdppc[index[:2]]
-        extrapolation = extrapolation_class(
-            data_to_extrapolate=current_hist_stock_pc, target_range=current_gdppc
-        )
-        pure_prediction[index] = extrapolation.regress()
-
-    prediction_out[...] = pure_prediction - (
-        pure_prediction[n_historic - 1, :] - historic_stocks_pc[n_historic - 1, :]
-    )
-    prediction_out[:n_historic, ...] = historic_stocks_pc

--- a/simson/common/data_transformations.py
+++ b/simson/common/data_transformations.py
@@ -11,17 +11,19 @@ from .data_extrapolations import (
 class StockExtrapolation:
 
     def __init__(
-            self, 
-            historic_stocks: fd.StockArray, 
-            dims: fd.DimensionSet, 
-            parameters: dict[str, fd.Parameter], 
-            stock_extrapolation_class: OneDimensionalExtrapolation, 
-            target_dim_letters=None
-        ):
+        self,
+        historic_stocks: fd.StockArray,
+        dims: fd.DimensionSet,
+        parameters: dict[str, fd.Parameter],
+        stock_extrapolation_class: OneDimensionalExtrapolation,
+        target_dim_letters=None,
+    ):
         self.historic_stocks = historic_stocks
         self.dims = dims
         self.parameters = parameters
-        self.stock_extrapolation_class = self.validate_extrapolation_class(stock_extrapolation_class)
+        self.stock_extrapolation_class = self.validate_extrapolation_class(
+            stock_extrapolation_class
+        )
         self.target_dim_letters = target_dim_letters
         self.regression_strategy = self.find_regression_strategy()
         self.n_fit_prms = self.stock_extrapolation_class.n_prms
@@ -29,15 +31,19 @@ class StockExtrapolation:
 
     def validate_extrapolation_class(self, extrapolation_class) -> OneDimensionalExtrapolation:
         """Check if the given extrapolation class is a valid subclass of OneDimensionalExtrapolation and return it."""
-        extrapolation_classes = {cls.__name__: cls for cls in OneDimensionalExtrapolation.__subclasses__()}
+        extrapolation_classes = {
+            cls.__name__: cls for cls in OneDimensionalExtrapolation.__subclasses__()
+        }
         if extrapolation_class not in extrapolation_classes:
-            raise ValueError(f'Extrapolation class must be one of {list(extrapolation_classes.keys())}')
+            raise ValueError(
+                f"Extrapolation class must be one of {list(extrapolation_classes.keys())}"
+            )
         return extrapolation_classes[extrapolation_class]
 
     def find_regression_strategy(self) -> Callable:
         """For now, only a regression based on GDP is implemented."""
         return self.gdp_regression
-        
+
     def extrapolate(self):
         self.per_capita_transformation()
         self.regression_strategy()

--- a/simson/plastics/plastics_mfa_system.py
+++ b/simson/plastics/plastics_mfa_system.py
@@ -1,7 +1,7 @@
 from typing import Optional
 import flodym as fd
 
-from simson.common.data_transformations import extrapolate_stock
+from simson.common.data_transformations import StockExtrapolation
 from simson.common.common_cfg import ModelCustomization
 
 
@@ -28,12 +28,13 @@ class PlasticsMFASystem(fd.MFASystem):
         self.stocks["in_use_historic"].compute()
 
     def compute_in_use_dsm(self):
-        in_use_stock = extrapolate_stock(
+        stock_handler = StockExtrapolation(
             self.stocks["in_use_historic"].stock,
             dims=self.dims,
             parameters=self.parameters,
             curve_strategy=self.cfg.customization.curve_strategy,
         )
+        in_use_stock = stock_handler.stocks
         self.stocks["in_use_dsm"].stock[...] = in_use_stock
         self.stocks["in_use_dsm"].lifetime_model.set_prms(
             mean=self.parameters["lifetime_mean"], std=self.parameters["lifetime_std"]

--- a/simson/plastics/plastics_mfa_system.py
+++ b/simson/plastics/plastics_mfa_system.py
@@ -32,7 +32,7 @@ class PlasticsMFASystem(fd.MFASystem):
             self.stocks["in_use_historic"].stock,
             dims=self.dims,
             parameters=self.parameters,
-            curve_strategy=self.cfg.customization.curve_strategy,
+            stock_extrapolation_class=self.cfg.customization.curve_strategy,
         )
         in_use_stock = stock_handler.stocks
         self.stocks["in_use_dsm"].stock[...] = in_use_stock

--- a/simson/steel/steel_model.py
+++ b/simson/steel/steel_model.py
@@ -4,7 +4,7 @@ import flodym.export as fde
 
 from simson.common.data_blending import blend, blend_over_time
 from simson.common.common_cfg import GeneralCfg
-from simson.common.data_transformations import extrapolate_stock, extrapolate_to_future
+from simson.common.data_transformations import StockExtrapolation, extrapolate_to_future
 from simson.common.custom_data_reader import CustomDataReader
 from simson.common.trade import TradeSet
 from simson.steel.steel_export import SteelDataExporter
@@ -109,13 +109,15 @@ class SteelModel:
 
     def get_long_term_stock(self):
         # extrapolate in use stock to future
-        total_in_use_stock = extrapolate_stock(
+        stock_handler = StockExtrapolation(
             self.historic_mfa.stocks["historic_in_use"].stock,
             dims=self.dims,
             parameters=self.parameters,
             curve_strategy=self.cfg.customization.curve_strategy,
             target_dim_letters=("t", "r"),
         )
+    
+        total_in_use_stock = stock_handler.stocks
 
         # calculate and apply sector splits for in use stock
         sector_splits = self.calc_stock_sector_splits(

--- a/simson/steel/steel_model.py
+++ b/simson/steel/steel_model.py
@@ -113,7 +113,7 @@ class SteelModel:
             self.historic_mfa.stocks["historic_in_use"].stock,
             dims=self.dims,
             parameters=self.parameters,
-            curve_strategy=self.cfg.customization.curve_strategy,
+            stock_extrapolation_class=self.cfg.customization.curve_strategy,
             target_dim_letters=("t", "r"),
         )
     


### PR DESCRIPTION
Extrapolation is now handled by a custom-made class: `StockExtrapolation`. This allows easy access to fit function and parameters used and hereby improves transparency. 
`data_extrapolations.py` was updated, too. The introduction of `func` allows a clear representation of the fit function. `n_prms` returns the number of free parameters in `func` which is used for saving them in `StockExtrapolation`.
Use of extrapolation was updated in steel and plastics mfa accordingly.

Limitation: `extrapolate_to_future` is not included yet. This PR focuses only on stock extrapolation.