### PR TITLE
Add flexible dimension fit + bug fix

### DIFF
--- a/simson/common/data_extrapolations.py
+++ b/simson/common/data_extrapolations.py
@@ -81,9 +81,7 @@ class Extrapolation(SimsonBaseModel):
 
     def regress(self):
         # extract dimensions that are regressed independently
-        target_shape = self.remove_shape_dimensions(
-            self.target_range.shape, self.independent_dims
-        )
+        target_shape = self.remove_shape_dimensions(self.target_range.shape, self.independent_dims)
         regression = np.zeros_like(self.target_range)
         self.fit_prms = np.zeros(self.target_range.shape[1:] + (self.n_prms,))
 

--- a/simson/common/data_extrapolations.py
+++ b/simson/common/data_extrapolations.py
@@ -13,8 +13,8 @@ class Extrapolation(SimsonBaseModel):
     """historical data, 1 dimensional"""
     target_range: np.ndarray
     """predictor variable(s) covering range of data_to_extrapolate and beyond"""
-    weights: np.ndarray = None
-    saturation_level: np.ndarray = None
+    weights: Optional[np.ndarray] = None
+    saturation_level: Optional[np.ndarray] = None
     independent_dims: Optional[Tuple[int, ...]] = ()
     """Indizes for dimensions across which to regress independently. Other dimensions are regressed commonly.
     If None, all dimensions are regressed individually. If empty (), all dimensions are regressed aggregately."""

--- a/simson/common/data_extrapolations.py
+++ b/simson/common/data_extrapolations.py
@@ -10,7 +10,7 @@ from scipy.optimize import least_squares
 class Extrapolation(SimsonBaseModel):
 
     data_to_extrapolate: np.ndarray
-    """historical data, 1 dimensional"""
+    """historical data"""
     target_range: np.ndarray
     """predictor variable(s) covering range of data_to_extrapolate and beyond"""
     weights: Optional[np.ndarray] = None
@@ -77,12 +77,7 @@ class Extrapolation(SimsonBaseModel):
     @staticmethod
     def remove_shape_dimensions(shape, retain_idx):
         """Removes dimensions from shape, except indices in retain_idx."""
-        result_shape = []
-
-        for i, dim_size in enumerate(shape):
-            if i in retain_idx:
-                result_shape.append(dim_size)
-
+        result_shape = [dim_size for i, dim_size in enumerate(shape) if i in retain_idx]
         return tuple(result_shape)
 
     def regress(self):

--- a/simson/common/data_extrapolations.py
+++ b/simson/common/data_extrapolations.py
@@ -73,7 +73,7 @@ class Extrapolation(SimsonBaseModel):
             return loss.flatten()
 
         return fitting_function
-    
+
     @staticmethod
     def remove_shape_dimensions(shape, retain_idx):
         """Removes dimensions from shape, except indices in retain_idx."""
@@ -88,7 +88,9 @@ class Extrapolation(SimsonBaseModel):
     def regress(self):
         # extract dimensions that are regressed independently
         if self.independent_dims is not None:
-            target_shape = self.remove_shape_dimensions(self.target_range.shape, self.independent_dims)
+            target_shape = self.remove_shape_dimensions(
+                self.target_range.shape, self.independent_dims
+            )
         else:
             target_shape = self.target_range.shape[1:]
         regression = np.zeros_like(self.target_range)

--- a/simson/common/data_extrapolations.py
+++ b/simson/common/data_extrapolations.py
@@ -73,21 +73,22 @@ class Extrapolation(SimsonBaseModel):
             return loss.flatten()
 
         return fitting_function
+    
+    @staticmethod
+    def remove_shape_dimensions(shape, retain_idx):
+        """Removes dimensions from shape, except indices in retain_idx."""
+        result_shape = []
+
+        for i, dim_size in enumerate(shape):
+            if i in retain_idx:
+                result_shape.append(dim_size)
+
+        return tuple(result_shape)
 
     def regress(self):
-        def remove_shape_dimensions(shape, retain_idx):
-            """Removes dimensions from shape, except indices in retain_idx."""
-            result_shape = []
-
-            for i, dim_size in enumerate(shape):
-                if i in retain_idx:
-                    result_shape.append(dim_size)
-
-            return tuple(result_shape)
-
         # extract dimensions that are regressed independently
         if self.independent_dims is not None:
-            target_shape = remove_shape_dimensions(self.target_range.shape, self.independent_dims)
+            target_shape = self.remove_shape_dimensions(self.target_range.shape, self.independent_dims)
         else:
             target_shape = self.target_range.shape[1:]
         regression = np.zeros_like(self.target_range)

--- a/simson/common/data_extrapolations.py
+++ b/simson/common/data_extrapolations.py
@@ -15,9 +15,8 @@ class Extrapolation(SimsonBaseModel):
     """predictor variable(s) covering range of data_to_extrapolate and beyond"""
     weights: Optional[np.ndarray] = None
     saturation_level: Optional[np.ndarray] = None
-    independent_dims: Optional[Tuple[int, ...]] = ()
-    """Indizes for dimensions across which to regress independently. Other dimensions are regressed commonly.
-    If None, all dimensions are regressed individually. If empty (), all dimensions are regressed aggregately."""
+    independent_dims: Tuple[int, ...] = ()
+    """Indizes for dimensions across which to regress independently. Other dimensions are regressed commonly."""
     fit_prms: np.ndarray = None
     n_prms: ClassVar[int]
 
@@ -82,12 +81,9 @@ class Extrapolation(SimsonBaseModel):
 
     def regress(self):
         # extract dimensions that are regressed independently
-        if self.independent_dims is not None:
-            target_shape = self.remove_shape_dimensions(
-                self.target_range.shape, self.independent_dims
-            )
-        else:
-            target_shape = self.target_range.shape[1:]
+        target_shape = self.remove_shape_dimensions(
+            self.target_range.shape, self.independent_dims
+        )
         regression = np.zeros_like(self.target_range)
         self.fit_prms = np.zeros(self.target_range.shape[1:] + (self.n_prms,))
 

--- a/simson/common/data_transformations.py
+++ b/simson/common/data_transformations.py
@@ -74,9 +74,7 @@ class StockExtrapolation:
     def get_fit_idx(self):
         """Get the indices of the fit dimensions in the historic_stocks dimensions."""
         self.fit_dim_idx = tuple(
-            i
-            for i, x in enumerate(self.historic_stocks.dims.letters)
-            if x in self.fit_dim_letters
+            i for i, x in enumerate(self.historic_stocks.dims.letters) if x in self.fit_dim_letters
         )
 
     def extrapolate(self):

--- a/simson/common/data_transformations.py
+++ b/simson/common/data_transformations.py
@@ -16,8 +16,12 @@ class StockExtrapolation:
         dims: fd.DimensionSet,
         parameters: dict[str, fd.Parameter],
         stock_extrapolation_class: Extrapolation,
-        target_dim_letters: Optional[Tuple[str, ...]] = None, # sets the dimensions of the stock extrapolation output
-        fit_dim_letters: Optional[Tuple[str, ...]] = None, # sets the dimensions across which an individual fit is performed, must be subset of target_dim_letters
+        target_dim_letters: Optional[
+            Tuple[str, ...]
+        ] = None,  # sets the dimensions of the stock extrapolation output
+        fit_dim_letters: Optional[
+            Tuple[str, ...]
+        ] = None,  # sets the dimensions across which an individual fit is performed, must be subset of target_dim_letters
         saturation_level: Optional[np.ndarray] = None,
         do_gdppc_accumulation: bool = True,
         stock_correction: str = "gaussian_first_order",  # Possible values "gaussian_first_order", "shift_zeroth_order", "none"
@@ -49,13 +53,13 @@ class StockExtrapolation:
 
         if fit_dim_letters is None:
             # fit_dim_letters should be the same as target_dim_letters, but without the time dimension
-            self.fit_dim_letters = tuple(x for x in self.target_dim_letters if x != 't')
+            self.fit_dim_letters = tuple(x for x in self.target_dim_letters if x != "t")
         else:
             self.fit_dim_letters = fit_dim_letters
             if not set(self.fit_dim_letters).issubset(self.target_dim_letters):
                 raise ValueError("fit_dim_letters must be subset of target_dim_letters.")
         self.get_fit_idx()
-    
+
     def get_fit_idx(self):
         """Get the indices of the fit dimensions in the historic_stocks dimensions."""
         a = self.historic_stocks.dims.letters
@@ -63,7 +67,7 @@ class StockExtrapolation:
         if b is None:
             self.fit_dim_idx = ()
         else:
-            self.fit_dim_idx = tuple(i for i, x in enumerate(a) if x in b)   
+            self.fit_dim_idx = tuple(i for i, x in enumerate(a) if x in b)
 
     def extrapolate(self):
         self.per_capita_transformation()
@@ -124,6 +128,7 @@ class StockExtrapolation:
         correction = taylor * gaussian(time_extended - last_history_year, approaching_time)
 
         return prediction[...] + correction
+
     def gdp_regression(self):
         """Updates per capita stock to future by extrapolation."""
 
@@ -133,7 +138,7 @@ class StockExtrapolation:
             b_reshaped = np.reshape(b, new_shape)
             b_broadcasted = np.broadcast_to(b_reshaped, a.shape)
             return b_broadcasted
-        
+
         prediction_out = self.stocks_pc.values
         pure_prediction = np.zeros_like(prediction_out)
         historic_in = self.historic_stocks_pc.values
@@ -142,10 +147,10 @@ class StockExtrapolation:
         n_historic = historic_in.shape[0]
 
         extrapolation = self.stock_extrapolation_class(
-                data_to_extrapolate=historic_in,
-                target_range=gdppc,
-                independent_dims=self.fit_dim_idx,
-                saturation_level=self.saturation_level,
+            data_to_extrapolate=historic_in,
+            target_range=gdppc,
+            independent_dims=self.fit_dim_idx,
+            saturation_level=self.saturation_level,
         )
         pure_prediction = extrapolation.regress()
 
@@ -161,6 +166,7 @@ class StockExtrapolation:
 
         # transform back to total stocks
         self.stocks[...] = self.stocks_pc * self.pop
+
 
 def extrapolate_to_future(
     historic_values: fd.FlodymArray, scale_by: fd.FlodymArray

--- a/simson/common/data_transformations.py
+++ b/simson/common/data_transformations.py
@@ -74,7 +74,9 @@ class StockExtrapolation:
     def get_fit_idx(self):
         """Get the indices of the fit dimensions in the historic_stocks dimensions."""
         self.fit_dim_idx = tuple(
-            i for i, x in enumerate(self.historic_stocks.dims.letters) if x in self.indep_fit_dim_letters
+            i
+            for i, x in enumerate(self.historic_stocks.dims.letters)
+            if x in self.indep_fit_dim_letters
         )
 
     def extrapolate(self):

--- a/simson/common/data_transformations.py
+++ b/simson/common/data_transformations.py
@@ -16,16 +16,27 @@ class StockExtrapolation:
         dims: fd.DimensionSet,
         parameters: dict[str, fd.Parameter],
         stock_extrapolation_class: Extrapolation,
-        target_dim_letters: Optional[
-            Tuple[str, ...]
-        ] = None,  # sets the dimensions of the stock extrapolation output
-        fit_dim_letters: Optional[
-            Tuple[str, ...]
-        ] = None,  # sets the dimensions across which an individual fit is performed, must be subset of target_dim_letters
+        target_dim_letters: Optional[Tuple[str, ...]] = None,
+        fit_dim_letters: Optional[Tuple[str, ...]] = None,
         saturation_level: Optional[np.ndarray] = None,
         do_gdppc_accumulation: bool = True,
-        stock_correction: str = "gaussian_first_order",  # Possible values "gaussian_first_order", "shift_zeroth_order", "none"
+        stock_correction: str = "gaussian_first_order",
     ):
+        """
+        Initialize the StockExtrapolation class.
+
+        Args:
+            historic_stocks (fd.StockArray): Historical stock data.
+            dims (fd.DimensionSet): Dimension set for the data.
+            parameters (dict[str, fd.Parameter]): Parameters for the extrapolation.
+            stock_extrapolation_class (Extrapolation): Class used for stock extrapolation.
+            target_dim_letters (Optional[Tuple[str, ...]], optional): Sets the dimensions of the stock extrapolation output. Defaults to None.
+            fit_dim_letters (Optional[Tuple[str, ...]], optional): Sets the dimensions across which an individual fit is performed, must be subset of target_dim_letters. Defaults to None.
+            saturation_level (Optional[np.ndarray], optional): Saturation level for the extrapolation. Defaults to None.
+            do_gdppc_accumulation (bool, optional): Flag to perform GDP per capita accumulation. Defaults to True.
+            stock_correction (str, optional): Method for stock correction. Possible values are "gaussian_first_order", "shift_zeroth_order", "none". Defaults to "gaussian_first_order".
+        """
+
         self.historic_stocks = historic_stocks
         self.dims = dims
         self.parameters = parameters
@@ -62,12 +73,10 @@ class StockExtrapolation:
 
     def get_fit_idx(self):
         """Get the indices of the fit dimensions in the historic_stocks dimensions."""
-        a = self.historic_stocks.dims.letters
-        b = self.fit_dim_letters
-        if b is None:
+        if self.fit_dim_letters is None:
             self.fit_dim_idx = ()
         else:
-            self.fit_dim_idx = tuple(i for i, x in enumerate(a) if x in b)
+            self.fit_dim_idx = tuple(i for i, x in enumerate(self.historic_stocks.dims.letters) if x in self.fit_dim_letters)
 
     def extrapolate(self):
         self.per_capita_transformation()

--- a/simson/common/data_transformations.py
+++ b/simson/common/data_transformations.py
@@ -17,7 +17,7 @@ class StockExtrapolation:
         parameters: dict[str, fd.Parameter],
         stock_extrapolation_class: Extrapolation,
         target_dim_letters: Optional[Tuple[str, ...]] = None,
-        fit_dim_letters: Optional[Tuple[str, ...]] = None,
+        indep_fit_dim_letters: Optional[Tuple[str, ...]] = (),
         saturation_level: Optional[np.ndarray] = None,
         do_gdppc_accumulation: bool = True,
         stock_correction: str = "gaussian_first_order",
@@ -31,7 +31,7 @@ class StockExtrapolation:
             parameters (dict[str, fd.Parameter]): Parameters for the extrapolation.
             stock_extrapolation_class (Extrapolation): Class used for stock extrapolation.
             target_dim_letters (Optional[Tuple[str, ...]], optional): Sets the dimensions of the stock extrapolation output. Defaults to None.
-            fit_dim_letters (Optional[Tuple[str, ...]], optional): Sets the dimensions across which an individual fit is performed, must be subset of target_dim_letters. Defaults to None.
+            indep_fit_dim_letters (Optional[Tuple[str, ...]], optional): Sets the dimensions across which an individual fit is performed, must be subset of target_dim_letters. If None, all dimensions given in target_dim_letters are regressed individually. If empty (), all dimensions are regressed aggregately. Defaults to ().
             saturation_level (Optional[np.ndarray], optional): Saturation level for the extrapolation. Defaults to None.
             do_gdppc_accumulation (bool, optional): Flag to perform GDP per capita accumulation. Defaults to True.
             stock_correction (str, optional): Method for stock correction. Possible values are "gaussian_first_order", "shift_zeroth_order", "none". Defaults to "gaussian_first_order".
@@ -42,7 +42,7 @@ class StockExtrapolation:
         self.parameters = parameters
         self.stock_extrapolation_class = stock_extrapolation_class
         self.target_dim_letters = target_dim_letters
-        self.set_dims(fit_dim_letters)
+        self.set_dims(indep_fit_dim_letters)
         self.saturation_level = saturation_level
         self.do_gdppc_accumulation = do_gdppc_accumulation
         self.stock_correction = stock_correction
@@ -73,14 +73,11 @@ class StockExtrapolation:
 
     def get_fit_idx(self):
         """Get the indices of the fit dimensions in the historic_stocks dimensions."""
-        if self.fit_dim_letters is None:
-            self.fit_dim_idx = ()
-        else:
-            self.fit_dim_idx = tuple(
-                i
-                for i, x in enumerate(self.historic_stocks.dims.letters)
-                if x in self.fit_dim_letters
-            )
+        self.fit_dim_idx = tuple(
+            i
+            for i, x in enumerate(self.historic_stocks.dims.letters)
+            if x in self.fit_dim_letters
+        )
 
     def extrapolate(self):
         self.per_capita_transformation()

--- a/simson/common/data_transformations.py
+++ b/simson/common/data_transformations.py
@@ -76,7 +76,11 @@ class StockExtrapolation:
         if self.fit_dim_letters is None:
             self.fit_dim_idx = ()
         else:
-            self.fit_dim_idx = tuple(i for i, x in enumerate(self.historic_stocks.dims.letters) if x in self.fit_dim_letters)
+            self.fit_dim_idx = tuple(
+                i
+                for i, x in enumerate(self.historic_stocks.dims.letters)
+                if x in self.fit_dim_letters
+            )
 
     def extrapolate(self):
         self.per_capita_transformation()

--- a/simson/steel/steel_model.py
+++ b/simson/steel/steel_model.py
@@ -152,7 +152,6 @@ class SteelModel:
             target_dim_letters=(
                 None if self.cfg.customization.do_stock_extrapolation_by_category else ("t", "r")
             ),
-            fit_dim_letters=("r",),
             saturation_level=saturation_level,
         )
         total_in_use_stock = stock_handler.stocks

--- a/simson/steel/steel_model.py
+++ b/simson/steel/steel_model.py
@@ -152,6 +152,9 @@ class SteelModel:
             target_dim_letters=(
                 None if self.cfg.customization.do_stock_extrapolation_by_category else ("t", "r")
             ),
+            indep_fit_dim_letters=(
+                ('r',) if self.cfg.customization.do_stock_extrapolation_by_category else ()
+            ),
             saturation_level=saturation_level,
         )
         total_in_use_stock = stock_handler.stocks

--- a/simson/steel/steel_model.py
+++ b/simson/steel/steel_model.py
@@ -153,7 +153,7 @@ class SteelModel:
                 None if self.cfg.customization.do_stock_extrapolation_by_category else ("t", "r")
             ),
             indep_fit_dim_letters=(
-                ('r',) if self.cfg.customization.do_stock_extrapolation_by_category else ()
+                ("r",) if self.cfg.customization.do_stock_extrapolation_by_category else ()
             ),
             saturation_level=saturation_level,
         )


### PR DESCRIPTION
### Features
Ability to set dimensions across which an individual stock fit should be performed. Dimensions not selected will be regressed aggregately. This change is accomplished by:
1. Introducing `fit_dim_letters` in `StockExtrapolation,` a Tuple of dimension letters across which an individual fit should be performed. If not given explicitly, it will be set similar to `target_dim_letters`, i.e. all dimensions in `target_dim_letters` will be regressed individually.
2. Introducing `fit_dim_idx`, a translation of the dim letters to their indices in the historic stock.
3. `gdp_regression` was simplified. Instead of looping to create individual fits, `independent_dims` is handed to the `Extrapolation` class.
4. In the `Extrapolation` class, `regress` now performs individual fits according to `independent_dims`. `regress_common` is a helper function that performs individual fits.

### Limitations
- `saturation_level` was added as a new attribute in `Extrapolation` and `StockExtrapolation`. A few further workarounds had to be employed to make everything work. Potentially this could be removed in the future, and instead it should be possible to prescribe ranges for every fit parameter, including saturation_level.

### Bug fixes
- Fixes error that set production to NaN when `do_stock_extrapolation_by_category` is set to `False`.