### PR TITLE
Add assumption tracking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "kaleido==0.1.0.post1",
     "flodym>=0.2.0",
     "black>=25.1.0",
+    "ipykernel>=6.29.5",
+    "nbformat>=5.10.4",
 ]
 
 [tool.setuptools]

--- a/run_simson.py
+++ b/run_simson.py
@@ -1,6 +1,7 @@
 import logging
 import yaml
 import flodym as fd
+import sys
 
 from simson.common.common_cfg import GeneralCfg
 from simson.plastics.plastics_model import PlasticsModel
@@ -21,7 +22,7 @@ def get_model_config(filename):
     return {k: v for k, v in data.items()}
 
 
-def init_mfa(cfg: dict) -> fd.MFASystem:
+def init_model(cfg: dict) -> fd.MFASystem:
     """Choose MFA subclass and return an initialized instance."""
 
     cfg = GeneralCfg.from_model_class(**cfg)
@@ -29,16 +30,11 @@ def init_mfa(cfg: dict) -> fd.MFASystem:
     return mfa
 
 
-def recalculate_mfa(model_config):
-    mfa = init_mfa(cfg=model_config)
+def calculate_model(model_config):
+    mfa = init_model(cfg=model_config)
     logging.info(f"{type(mfa).__name__} instance created.")
     mfa.run()
     logging.info("Model computations completed.")
-
-
-def visualize_mfa(model_config):
-    # TODO: Implement load of MFA to visualize without recalculating
-    pass
 
 
 def run_simson(cfg_file: str):
@@ -49,9 +45,12 @@ def run_simson(cfg_file: str):
     )
 
     model_config = get_model_config(cfg_file)
-    recalculate_mfa(model_config)
+    calculate_model(model_config)
 
 
 if __name__ == "__main__":
-    cfg_file = "config/plastics.yml"
+    try:
+        cfg_file = sys.argv[1]
+    except IndexError:
+        raise ValueError("Please provide a configuration file as an argument.")
     run_simson(cfg_file)

--- a/simson/common/assumptions_doc.py
+++ b/simson/common/assumptions_doc.py
@@ -1,0 +1,76 @@
+from inspect import stack, getframeinfo
+from pydantic import field_validator
+from typing import ClassVar, Any, Optional
+import os
+
+from simson.common.base_model import SimsonBaseModel
+
+
+_assumptions = []
+
+
+def add_assumption_doc(type: str, name: str, description: str, value: str=None, source: str = None):
+    """
+    Add an assumption to the list of assumptions. The assumption is stored in a global list
+    and can be printed later using the print_assumptions() function.
+    Args:
+        type (str): The type of the assumption. Must be one of the allowed types:
+            "ad-hoc fix", "model assumption", "integer number", "literature value".
+        name (str): The name of the assumption. This should be a short, descriptive name.
+        description (str): A thorough explanation of the assumption. Should be understandable for
+            users of the model without knowledge of the code.
+        value (str, optional): The value of the assumption, if applicable. Defaults to None.
+        source (str, optional): The source for literature data. Defaults to None.
+    """
+    caller = getframeinfo(stack()[1][0])
+    assumption = Assumption(
+        type=type,
+        name=name,
+        value=value,
+        description=description,
+        filename=caller.filename,
+        line_number=caller.lineno,
+        source=source,
+    )
+    _assumptions.append(assumption)
+
+
+class Assumption(SimsonBaseModel):
+    type: str
+    name: str
+    description: str
+    filename: str
+    line_number: int
+    value: Optional[Any] = None
+    source: Optional[str] = None
+    _allowed_types: ClassVar = [
+        "ad-hoc fix",
+        "model assumption",
+        "integer number",
+        "literature value",
+    ]
+
+    @field_validator("type", mode="after")
+    @classmethod
+    def check_type(cls, v):
+        if v not in cls._allowed_types:
+            raise ValueError("assumption type must be one of: " + str(cls._allowed_types))
+        return v
+
+    def __str__(self):
+        str_out = "Assumption:\n"
+        str_out += f"  Type: {self.type}\n"
+        str_out += f"  Name: {self.name}\n"
+        if self.value is not None:
+            str_out += f"  Value: {self.value}\n"
+        str_out += f"  Description: {self.description}\n"
+        if self.source is not None:
+            str_out += f"  Source: {self.source}\n"
+        root_dir = os.path.abspath(os.curdir)
+        filename_rel = os.path.relpath(self.filename, root_dir)
+        str_out += f"  File: {filename_rel}, Line: {self.line_number}"
+        return str_out
+
+
+def assumptions_str() -> str:
+    return "\n".join(str(a) for a in _assumptions)

--- a/simson/common/common_cfg.py
+++ b/simson/common/common_cfg.py
@@ -42,6 +42,12 @@ class ModelCustomization(SimsonBaseModel):
         return choose_subclass_by_name(self.stock_extrapolation_class_name, Extrapolation)
 
 
+class ExportCfg(SimsonBaseModel):
+    csv: bool = True
+    pickle: bool = True
+    assumptions: bool = True
+
+
 class VisualizationCfg(SimsonBaseModel):
 
     use_stock: dict = {"do_visualize": False}
@@ -83,7 +89,7 @@ class GeneralCfg(SimsonBaseModel):
     customization: ModelCustomization
     visualization: VisualizationCfg
     output_path: str
-    do_export: dict[str, bool]
+    do_export: ExportCfg
 
     @classmethod
     def from_model_class(cls, **kwargs) -> "GeneralCfg":

--- a/simson/common/common_cfg.py
+++ b/simson/common/common_cfg.py
@@ -11,7 +11,7 @@ IMPLEMENTED_MODELS = [
 ]
 
 
-def choose_sublass_by_name(name: str, parent: type) -> type:
+def choose_subclass_by_name(name: str, parent: type) -> type:
 
     def recurse_subclasses(cls):
         return set(cls.__subclasses__()).union(
@@ -34,12 +34,12 @@ class ModelCustomization(SimsonBaseModel):
 
     @property
     def lifetime_model(self) -> fd.LifetimeModel:
-        return choose_sublass_by_name(self.lifetime_model_name, fd.LifetimeModel)
+        return choose_subclass_by_name(self.lifetime_model_name, fd.LifetimeModel)
 
     @property
     def stock_extrapolation_class(self) -> Extrapolation:
         """Check if the given extrapolation class is a valid subclass of OneDimensionalExtrapolation and return it."""
-        return choose_sublass_by_name(self.stock_extrapolation_class_name, Extrapolation)
+        return choose_subclass_by_name(self.stock_extrapolation_class_name, Extrapolation)
 
 
 class VisualizationCfg(SimsonBaseModel):
@@ -50,6 +50,7 @@ class VisualizationCfg(SimsonBaseModel):
     do_show_figs: bool = True
     do_save_figs: bool = False
     plotting_engine: str = "plotly"
+    plotly_renderer: str = "browser"
 
 
 class CementVisualizationCfg(VisualizationCfg):

--- a/simson/common/common_export.py
+++ b/simson/common/common_export.py
@@ -9,12 +9,13 @@ import flodym as fd
 import flodym.export as fde
 
 from simson.common.base_model import SimsonBaseModel
-from simson.common.common_cfg import VisualizationCfg
+from simson.common.common_cfg import VisualizationCfg, ExportCfg
+from simson.common.assumptions_doc import assumptions_str
 
 
 class CommonDataExporter(SimsonBaseModel):
     output_path: str
-    do_export: dict = {"pickle": True, "csv": True}
+    do_export: ExportCfg
     cfg: VisualizationCfg
     _display_names: dict = {}
 
@@ -25,12 +26,16 @@ class CommonDataExporter(SimsonBaseModel):
         return self
 
     def export_mfa(self, mfa: fd.MFASystem):
-        if self.do_export["pickle"]:
+        if self.do_export.pickle:
             fde.export_mfa_to_pickle(mfa=mfa, export_path=self.export_path("mfa.pickle"))
-        if self.do_export["csv"]:
+        if self.do_export.csv:
             dir_out = os.path.join(self.export_path(), "flows")
             fde.export_mfa_flows_to_csv(mfa=mfa, export_directory=dir_out)
             fde.export_mfa_stocks_to_csv(mfa=mfa, export_directory=dir_out)
+        if self.do_export.assumptions:
+            file_out = os.path.join(self.export_path("assumptions.txt"))
+            with open(file_out, "w") as f:
+                f.write(assumptions_str())
 
     def export_path(self, filename: str = None):
         path_tuple = (self.output_path, "export")

--- a/simson/common/common_export.py
+++ b/simson/common/common_export.py
@@ -1,12 +1,14 @@
 import os
 from matplotlib import pyplot as plt
-from simson.common.base_model import SimsonBaseModel
 import plotly.graph_objects as go
+import plotly.colors as plc
+import plotly.io as pio
+from typing import Optional
+from pydantic import model_validator
 import flodym as fd
 import flodym.export as fde
-from plotly import colors as plc
-from typing import Optional
 
+from simson.common.base_model import SimsonBaseModel
 from simson.common.common_cfg import VisualizationCfg
 
 
@@ -15,6 +17,12 @@ class CommonDataExporter(SimsonBaseModel):
     do_export: dict = {"pickle": True, "csv": True}
     cfg: VisualizationCfg
     _display_names: dict = {}
+
+    @model_validator(mode="after")
+    def set_plotly_renderer(self):
+        if self.cfg.plotting_engine == "plotly":
+            pio.renderers.default = self.cfg.plotly_renderer
+        return self
 
     def export_mfa(self, mfa: fd.MFASystem):
         if self.do_export["pickle"]:

--- a/simson/common/stock_extrapolation.py
+++ b/simson/common/stock_extrapolation.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 
 from simson.common.data_extrapolations import Extrapolation
 from simson.common.data_transformations import broadcast_trailing_dimensions, BoundList
+from simson.common.assumptions_doc import add_assumption_doc
 
 
 class StockExtrapolation:
@@ -96,6 +97,66 @@ class StockExtrapolation:
         self.historic_gdppc[...] = self.gdppc[{"t": self.dims["h"]}]
         self.historic_stocks_pc[...] = self.historic_stocks / self.historic_pop
 
+    def gdp_regression(self):
+        """Updates per capita stock to future by extrapolation."""
+
+        prediction_out = self.stocks_pc.values.copy()
+        historic_in = self.historic_stocks_pc.values
+        gdppc = self.gdppc_acc if self.do_gdppc_accumulation else self.gdppc
+        gdppc = broadcast_trailing_dimensions(gdppc, prediction_out)
+        n_historic = historic_in.shape[0]
+
+        n_deriv = 5
+        add_assumption_doc(
+            type="integer number",
+            name="n years for regression derivative correction",
+            value=n_deriv,
+            description=(
+                "Number of historic years used for determination of regressed and actual "
+                "growth rates of ins-use stocks, which are then used for a correction "
+                "reconciling the two and blending from observed to regression."
+            )
+        )
+
+        add_assumption_doc(
+            name="synthetic recent GDP for regression correction",
+            type="ad-hoc fix",
+            description=(
+                "GDP per capita SSP curves assume a steady growth after 2025, which in some "
+                "regions breaks historic trends. Here, we overwrite recent historic GDP per capita "
+                "by extrapolating back from 2025 using the growth rates after 2025. "
+                "This creates continuity between the recent historic GDP growth used for the "
+                "gaussian correction and the future assumed growth rates and thereby prevents "
+                "discontinuities in production."
+            ),
+        )
+        gdppc = deepcopy(gdppc)
+        growth = (gdppc[126]/gdppc[127])
+        for i in range(n_deriv + 5):
+            gdppc[125-i, ...] = gdppc[125-i+1, ...] * growth
+
+        extrapolation = self.stock_extrapolation_class(
+            data_to_extrapolate=historic_in,
+            target_range=gdppc,
+            independent_dims=self.fit_dim_idx,
+            bound_list=self.bound_list,
+        )
+        pure_prediction = extrapolation.regress()
+
+        if self.stock_correction == "gaussian_first_order":
+            prediction_out[...] = self.gaussian_correction(historic_in, pure_prediction, n_deriv)
+        elif self.stock_correction == "shift_zeroth_order":
+            # match last point by adding the difference between the last historic point and the corresponding prediction
+            prediction_out[...] = pure_prediction - (
+                pure_prediction[n_historic - 1, :] - historic_in[n_historic - 1, :]
+            )
+
+        prediction_out[:n_historic, ...] = historic_in
+        self.stocks_pc.set_values(prediction_out)
+
+        # transform back to total stocks
+        self.stocks[...] = self.stocks_pc * self.pop
+
     def gaussian_correction(
         self, historic: np.ndarray, prediction: np.ndarray, approaching_time: float = 50, n: int = 5
     ):
@@ -131,46 +192,28 @@ class StockExtrapolation:
             a = np.sqrt(np.log(20))
             return np.exp(-((a * t / approaching_time) ** 2))
 
+        approaching_time_0th = 50
+        add_assumption_doc(
+            type="integer number",
+            name="years for absolute blending to regression",
+            value=approaching_time_0th,
+            description=(
+                "Number of years for the blending from historical to regressed in-use stocks. "
+            ),
+        )
+        approaching_time_1st = 30
+        add_assumption_doc(
+            type="integer number",
+            name="years for derivative blending to regression",
+            value=approaching_time_1st,
+            description=(
+                "Number of years for the blending from historical to regressed in-use stock "
+                "growth rates. "
+            )
+        )
         time_extended = time.reshape(-1, *([1] * len(difference_0th.shape)))
         corr0 = difference_0th * gaussian(time_extended - last_history_year, 50)
         corr1 = difference_1st * (time_extended - last_history_year) * gaussian(time_extended - last_history_year, 30)
         correction = corr0 + corr1
 
         return prediction[...] + correction
-
-    def gdp_regression(self):
-        """Updates per capita stock to future by extrapolation."""
-
-        prediction_out = self.stocks_pc.values.copy()
-        historic_in = self.historic_stocks_pc.values
-        gdppc = self.gdppc_acc if self.do_gdppc_accumulation else self.gdppc
-        gdppc = broadcast_trailing_dimensions(gdppc, prediction_out)
-        n_historic = historic_in.shape[0]
-
-        n_deriv = 5
-        gdppc = deepcopy(gdppc)
-        growth = (gdppc[126]/gdppc[127])
-        for i in range(n_deriv + 5):
-            gdppc[125-i, ...] = gdppc[125-i+1, ...] * growth
-
-        extrapolation = self.stock_extrapolation_class(
-            data_to_extrapolate=historic_in,
-            target_range=gdppc,
-            independent_dims=self.fit_dim_idx,
-            bound_list=self.bound_list,
-        )
-        pure_prediction = extrapolation.regress()
-
-        if self.stock_correction == "gaussian_first_order":
-            prediction_out[...] = self.gaussian_correction(historic_in, pure_prediction, n_deriv)
-        elif self.stock_correction == "shift_zeroth_order":
-            # match last point by adding the difference between the last historic point and the corresponding prediction
-            prediction_out[...] = pure_prediction - (
-                pure_prediction[n_historic - 1, :] - historic_in[n_historic - 1, :]
-            )
-
-        prediction_out[:n_historic, ...] = historic_in
-        self.stocks_pc.set_values(prediction_out)
-
-        # transform back to total stocks
-        self.stocks[...] = self.stocks_pc * self.pop

--- a/simson/steel/steel_model.py
+++ b/simson/steel/steel_model.py
@@ -12,6 +12,7 @@ from simson.steel.steel_export import SteelDataExporter
 from simson.steel.steel_mfa_system_future import StockDrivenSteelMFASystem
 from simson.steel.steel_mfa_system_historic import InflowDrivenHistoricSteelMFASystem
 from simson.steel.steel_definition import get_definition
+from simson.common.assumptions_doc import add_assumption_doc
 
 
 class SteelModel:
@@ -36,8 +37,19 @@ class SteelModel:
 
     def modify_parameters(self):
         """Manual changes to parameters in order to match historical scrap consumption."""
+
+        scalar_lifetime_factor = 1.1
+        add_assumption_doc(
+            type="ad-hoc fix",
+            name="overall lifetime factor",
+            value=scalar_lifetime_factor,
+            description=(
+                "Factor multiplied to all lifetime means and standard deviations to match "
+                "historical scrap consumption."
+            ),
+        )
         lifetime_factor = fd.Parameter(dims=self.dims["t", "r"])
-        lifetime_factor.values[...] = 1.1
+        lifetime_factor.values[...] = scalar_lifetime_factor
         self.parameters["lifetime_factor"] = lifetime_factor
 
         self.parameters["lifetime_mean"] = fd.Parameter(
@@ -48,13 +60,33 @@ class SteelModel:
             dims=self.dims["t", "r", "g"],
             values=(self.parameters["lifetime_factor"] * self.parameters["lifetime_std"]).values,
         )
+        construction_lifetime_factor = 1.1
+        add_assumption_doc(
+            type="ad-hoc fix",
+            name="construction lifetime factor",
+            value=construction_lifetime_factor,
+            description=(
+                "Additional factor multiplied to construction lifetime mean and standard deviation "
+                "to match historical scrap consumption. The special treatment of construction "
+                "is motivated by literature sources suggesting longer building lifetimes than the "
+                "used source"
+            ),
+        )
         self.parameters["lifetime_mean"]["Construction"] = (
-            self.parameters["lifetime_mean"]["Construction"] * 1.4
+            self.parameters["lifetime_mean"]["Construction"] * construction_lifetime_factor
         )
         self.parameters["lifetime_std"]["Construction"] = (
-            self.parameters["lifetime_std"]["Construction"] * 1.4
+            self.parameters["lifetime_std"]["Construction"] * construction_lifetime_factor
         )
 
+        add_assumption_doc(
+            type="ad-hoc fix",
+            name="scrap rate factor",
+            description=(
+                "Time-dependent factor multiplied to forming and fabrication losses to match "
+                "historical scrap consumption."
+            ),
+        )
         scrap_rate_factor = fd.Parameter(dims=self.dims["t",])
         scrap_rate_factor.values[:80] = 1.4
         scrap_rate_factor.values[80:110] = np.linspace(1.4, 0.8, 30)
@@ -183,6 +215,16 @@ class SteelModel:
             high_stock_sector_split = self.get_high_stock_sector_split()
             saturation_level = saturation_level * high_stock_sector_split.values
 
+        saturation_level_factor = 0.75
+        add_assumption_doc(
+            type="ad-hoc fix",
+            name="saturation level factor",
+            value=saturation_level_factor,
+            description=(
+                "Factor multiplied to regressed saturation level to reduce future steel demand "
+                "in line with other literature sources."
+            ),
+        )
         saturation_level *= 0.75
 
         return saturation_level

--- a/simson/steel/steel_model.py
+++ b/simson/steel/steel_model.py
@@ -37,7 +37,7 @@ class SteelModel:
     def modify_parameters(self):
         """Manual changes to parameters in order to match historical scrap consumption."""
         lifetime_factor = fd.Parameter(dims=self.dims["t", "r"])
-        lifetime_factor.values[...] = 1.3
+        lifetime_factor.values[...] = 1.1
         self.parameters["lifetime_factor"] = lifetime_factor
 
         self.parameters["lifetime_mean"] = fd.Parameter(
@@ -49,10 +49,10 @@ class SteelModel:
             values=(self.parameters["lifetime_factor"] * self.parameters["lifetime_std"]).values,
         )
         self.parameters["lifetime_mean"]["Construction"] = (
-            self.parameters["lifetime_mean"]["Construction"] * 1.5
+            self.parameters["lifetime_mean"]["Construction"] * 1.4
         )
         self.parameters["lifetime_std"]["Construction"] = (
-            self.parameters["lifetime_std"]["Construction"] * 1.5
+            self.parameters["lifetime_std"]["Construction"] * 1.4
         )
 
         scrap_rate_factor = fd.Parameter(dims=self.dims["t",])
@@ -182,6 +182,8 @@ class SteelModel:
         if self.cfg.customization.do_stock_extrapolation_by_category:
             high_stock_sector_split = self.get_high_stock_sector_split()
             saturation_level = saturation_level * high_stock_sector_split.values
+
+        saturation_level *= 0.75
 
         return saturation_level
 

--- a/simson_cement.py
+++ b/simson_cement.py
@@ -1,4 +1,7 @@
+#%%
 from run_simson import run_simson
 
 cfg_file = "config/cement.yml"
 run_simson(cfg_file)
+
+#%%

--- a/simson_plastics.py
+++ b/simson_plastics.py
@@ -1,4 +1,7 @@
+#%%
 from run_simson import run_simson
 
 cfg_file = "config/plastics.yml"
 run_simson(cfg_file)
+
+#%%

--- a/simson_steel.py
+++ b/simson_steel.py
@@ -1,4 +1,7 @@
+#%%
 from run_simson import run_simson
 
 cfg_file = "config/steel.yml"
 run_simson(cfg_file)
+
+# %%


### PR DESCRIPTION
Awful PR, since it does several things: 

- Adds functionality to document assumptions made in the code and export them to a file; Could be extended in the future by e.g. a sorting or filtering functionality. 
- Implements some of these assumptions for steel. Aim is to have complete coverage. 
- Adds functionality to run in interactive mode and show Figures in VSCode via jupyters "notebook" renderer. 
- Adds functionality to run simson from `run_simson` file with config file as an argument.
  - In the future, we could combine all the single main-files into one, since all it does is run interactively, and that can be done chunk by chunk. Didn't want to break backwards compatibility, though.
- Slightly modify calculation of Gaussian regression to allow for different approaching times for value and derivative.
  - Those could be made an external parameter if we can't find one that we're happy with for all models. Requires cfg being passed to stock extrapolation
- Add synthetic back-extrapolation of gdppc using future growth rates to fix discontinuities in LAM/MEA steel demand
  - Could be made optional in the future. Requires cfg being passed to stock extrapolation. 
- Change some steel ad-hoc parameters 
- Implement plotting gdppc rate-of-change for steel (routine could be moved to common visualization, and config prms could be added to actually plot rate-of-change; is not used anywhere right now) 