### PR TITLE
add high value chemicals input

### DIFF
--- a/config/cement.yml
+++ b/config/cement.yml
@@ -3,7 +3,7 @@ model: 'cement'
 input:
   force_extract_tgz: False
   input_data_path: '../remind_mfa_data'
-  input_data_revision: '1.3.0'
+  input_data_revision: '1.4.0'
   region_mapping: 'h12'
   scenarios_path: 'config/scenarios'
 

--- a/config/plastics.yml
+++ b/config/plastics.yml
@@ -46,12 +46,13 @@ visualization:
   extrapolation:
     do_visualize: True
   sankey:
-    do_visualize: False
+    do_visualize: True
     plotter_args:
       slice_dict:
-        t: 2019
+        t: 2050
         #r: 'EUR'
         #m: 'Fibres'
+        e: 'C'
       exclude_processes:
         - "sysenv"
         #- "waste_market"

--- a/config/plastics.yml
+++ b/config/plastics.yml
@@ -3,7 +3,7 @@ model: 'plastics'
 input:
   force_extract_tgz: False
   input_data_path: '../remind_mfa_data'
-  input_data_revision: '1.3.0'
+  input_data_revision: '1.4.0'
   region_mapping: 'h12'
   scenarios_path: 'config/scenarios'
 

--- a/config/steel.yml
+++ b/config/steel.yml
@@ -4,7 +4,7 @@ input:
   force_extract_tgz: False
   scenarios_path: 'config/scenarios'
   input_data_path: '../remind_mfa_data/'
-  input_data_revision: '1.3.0'
+  input_data_revision: '1.4.0'
   region_mapping: 'h12'
 
 model_switches:

--- a/remind_mfa/plastics/plastics_definition.py
+++ b/remind_mfa/plastics/plastics_definition.py
@@ -54,7 +54,7 @@ def get_plastics_definition(cfg: PlasticsCfg, historic: bool) -> RemindMFADefini
             "captured",
             "atmosphere",
             "other_reactants",
-            "losses"
+            "losses",
         ]
 
     # fmt: off

--- a/remind_mfa/plastics/plastics_definition.py
+++ b/remind_mfa/plastics/plastics_definition.py
@@ -28,11 +28,13 @@ def get_plastics_definition(cfg: PlasticsCfg, historic: bool) -> RemindMFADefini
     else:
         processes = [
             "sysenv",
-            "virginfoss",
-            "virginbio",
-            "virgindaccu",
-            "virginccu",
-            "virgin",
+            "feedfoss",
+            "feedbio",
+            "feeddaccu",
+            "feedccu",
+            "HVC_input",
+            "C4_input",
+            "polymerization",
             "fabrication",
             "primary_market",
             "waste_market",
@@ -51,6 +53,8 @@ def get_plastics_definition(cfg: PlasticsCfg, historic: bool) -> RemindMFADefini
             "emission",
             "captured",
             "atmosphere",
+            "other_reactants",
+            "losses"
         ]
 
     # fmt: off
@@ -67,19 +71,26 @@ def get_plastics_definition(cfg: PlasticsCfg, historic: bool) -> RemindMFADefini
     else:
         flows = [
             # sysenv
-            fd.FlowDefinition(from_process="sysenv", to_process="virginfoss", dim_letters=("t","e","r")),
-            fd.FlowDefinition(from_process="sysenv", to_process="virginccu", dim_letters=("t","e","r")),
+            fd.FlowDefinition(from_process="sysenv", to_process="feedfoss", dim_letters=("t","e","r")),
+            fd.FlowDefinition(from_process="sysenv", to_process="feedccu", dim_letters=("t","e","r")),
             fd.FlowDefinition(from_process="exports", to_process="sysenv", dim_letters=("t","e","r")),
             fd.FlowDefinition(from_process="sysenv", to_process="imports", dim_letters=("t","e","r")),
+            fd.FlowDefinition(from_process="sysenv", to_process="C4_input", dim_letters=("t","e","r")),
+            fd.FlowDefinition(from_process="sysenv", to_process="other_reactants", dim_letters=("t","e","r")),
+            fd.FlowDefinition(from_process="losses", to_process="sysenv", dim_letters=("t","e","r")),
             # monomer stages
-            fd.FlowDefinition(from_process="atmosphere", to_process="virginbio", dim_letters=("t","e","r")),
-            fd.FlowDefinition(from_process="atmosphere", to_process="virgindaccu", dim_letters=("t","e","r")),
-            fd.FlowDefinition(from_process="virginfoss", to_process="virgin", dim_letters=("t","e","r")),
-            fd.FlowDefinition(from_process="virginbio", to_process="virgin", dim_letters=("t","e","r")),
-            fd.FlowDefinition(from_process="virgindaccu", to_process="virgin", dim_letters=("t","e","r")),
-            fd.FlowDefinition(from_process="virginccu", to_process="virgin", dim_letters=("t","e","r")),
+            fd.FlowDefinition(from_process="atmosphere", to_process="feedbio", dim_letters=("t","e","r")),
+            fd.FlowDefinition(from_process="atmosphere", to_process="feeddaccu", dim_letters=("t","e","r")),
+            fd.FlowDefinition(from_process="feedfoss", to_process="HVC_input", dim_letters=("t","e","r")),
+            fd.FlowDefinition(from_process="feedbio", to_process="HVC_input", dim_letters=("t","e","r")),
+            fd.FlowDefinition(from_process="feeddaccu", to_process="HVC_input", dim_letters=("t","e","r")),
+            fd.FlowDefinition(from_process="feedccu", to_process="HVC_input", dim_letters=("t","e","r")),
+            fd.FlowDefinition(from_process="HVC_input", to_process="polymerization", dim_letters=("t","e","r")),
+            fd.FlowDefinition(from_process="C4_input", to_process="polymerization", dim_letters=("t","e","r")),
+            fd.FlowDefinition(from_process="other_reactants", to_process="polymerization", dim_letters=("t","e","r")),
             # primary stages
-            fd.FlowDefinition(from_process="virgin", to_process="primary_market", dim_letters=("t","e","r","m")),
+            fd.FlowDefinition(from_process="polymerization", to_process="primary_market", dim_letters=("t","e","r","m")),
+            fd.FlowDefinition(from_process="polymerization", to_process="losses", dim_letters=("t","e","r","m")),
             fd.FlowDefinition(from_process="primary_market", to_process="fabrication", dim_letters=("t","e","r","m")),
             fd.FlowDefinition(from_process="primary_market", to_process="exports", dim_letters=("t","e","r","m")),
             fd.FlowDefinition(from_process="imports", to_process="primary_market", dim_letters=("t","e","r","m")),
@@ -99,14 +110,14 @@ def get_plastics_definition(cfg: PlasticsCfg, historic: bool) -> RemindMFADefini
             fd.FlowDefinition(from_process="collected", to_process="incineration", dim_letters=("t","e","r","m")),
             fd.FlowDefinition(from_process="mismanaged", to_process="uncontrolled", dim_letters=("t","e","r","m")),
             fd.FlowDefinition(from_process="reclmech", to_process="fabrication", dim_letters=("t","e","r","m")),
-            fd.FlowDefinition(from_process="reclchem", to_process="virgin", dim_letters=("t","e","r")),
+            fd.FlowDefinition(from_process="reclchem", to_process="HVC_input", dim_letters=("t","e","r")),
             fd.FlowDefinition(from_process="reclchem", to_process="emission", dim_letters=("t","e","r")),
             fd.FlowDefinition(from_process="reclmech", to_process="uncontrolled", dim_letters=("t","e","r","m")),
             fd.FlowDefinition(from_process="reclmech", to_process="incineration", dim_letters=("t","e","r","m")),
             fd.FlowDefinition(from_process="incineration", to_process="emission", dim_letters=("t","e","r")),
             fd.FlowDefinition(from_process="emission", to_process="captured", dim_letters=("t","e","r")),
             fd.FlowDefinition(from_process="emission", to_process="atmosphere", dim_letters=("t","e","r")),
-            fd.FlowDefinition(from_process="captured", to_process="virginccu", dim_letters=("t","e","r")),
+            fd.FlowDefinition(from_process="captured", to_process="feedccu", dim_letters=("t","e","r")),
             # waste trade
             fd.FlowDefinition(from_process="waste_market", to_process="collected", dim_letters=("t","e","r","m")),
             fd.FlowDefinition(from_process="collected", to_process="waste_market", dim_letters=("t","e","r","m")),
@@ -185,11 +196,18 @@ def get_plastics_definition(cfg: PlasticsCfg, historic: bool) -> RemindMFADefini
                                      description="Historic plastic waste imports",),
         RemindMFAParameterDefinition(name="waste_his_exports", dim_letters=("h", "r", "m"),
                                      description="Historic plastic waste exports",),
-        # virgin production rates
+        # renewable production rates
         RemindMFAParameterDefinition(name="bio_production_rate", dim_letters=("h", "r"),
-                                     description="Share of bio-based plastics in virgin production",),
+                                     description="Share of bio-based HVC production",),
         RemindMFAParameterDefinition(name="daccu_production_rate", dim_letters=("h", "r"),
-                                     description="Share of DACCU plastics in virgin production",),
+                                     description="Share of DACCU HVC production",),
+        # HVC input
+        RemindMFAParameterDefinition(name="HVC_input_ratio", dim_letters=("m", "e"),
+                                     description="Ratio of HVC inputs to polymerization",),
+        RemindMFAParameterDefinition(name="C4_input_ratio", dim_letters=("m", "e"),
+                                     description="Ratio of C4 inputs to polymerization",),
+        RemindMFAParameterDefinition(name="polymerization_yield", dim_letters=("m",),
+                                     description="Polymerization yield",),
         # recycling losses
         RemindMFAParameterDefinition(name="mechanical_recycling_yield", dim_letters=("t", "r", "m"),
                                      description="Yield of mechanical recycling",),

--- a/remind_mfa/plastics/plastics_mappings.py
+++ b/remind_mfa/plastics/plastics_mappings.py
@@ -13,11 +13,15 @@ class PlasticsDimensionFiles(CommonDimensionFiles):
 class PlasticsDisplayNames(CommonDisplayNames):
     _own_mapping = {
         "sysenv": "System environment",
-        "virginfoss": "Feedstock(fossil)",
-        "virginbio": "Feedstock(biomass)",
-        "virgindaccu": "Feedstock(daccu)",
-        "virginccu": "Feedstock(ccu)",
-        "virgin": "Virgin Production",
+        "feedfoss": "Feedstock(fossil)",
+        "feedbio": "Feedstock(biomass)",
+        "feeddaccu": "Feedstock(daccu)",
+        "feedccu": "Feedstock(ccu)",
+        "HVC_input": "High Value Chemical input",
+        "C4_input": "C4 input",
+        "other_reactants": "Other Reactants",
+        "polymerization": "Polymerization",
+        "losses": "Losses",
         "processing": "Processing",
         "fabrication": "Fabrication",
         "reclmech": "Mechanical Recycling",
@@ -36,4 +40,6 @@ class PlasticsDisplayNames(CommonDisplayNames):
         "primary_market": "Primary Market",
         "intermediate_market": "Intermediate Market",
         "good_market": "Good Market",
+        "imports": "Imports",
+        "exports": "Exports",
     }

--- a/remind_mfa/plastics/plastics_mfa_system.py
+++ b/remind_mfa/plastics/plastics_mfa_system.py
@@ -91,7 +91,7 @@ class PlasticsMFASystemFuture(CommonMFASystem):
         flw["reclmech => incineration"][...] = aux["reclmech_loss"] - flw["reclmech => uncontrolled"]
 
         flw["collected => reclchem"][...] = aux["total_waste_collected"] * prm["chemical_recycling_rate"]
-        
+
         flw["collected => incineration"][...] = aux["total_waste_collected"] * prm["incineration_rate"]
         flw["incineration => emission"][...] = flw["collected => incineration"] + flw["reclmech => incineration"]
 
@@ -161,11 +161,11 @@ class PlasticsMFASystemFuture(CommonMFASystem):
         flw["reclchem => HVC_input"][...] = flw["collected => reclchem"].sum_to(("t", "r")) * aux["HVC_c_content"] * prm["chemical_recycling_yield"] # TODO: differentiate yield by element instead of using C content of HVC!
         flw["reclchem => emission"][...] = flw["collected => reclchem"] - flw["reclchem => HVC_input"]
         aux["total_primary_HVC"][...] = flw["HVC_input => polymerization"] - flw["reclchem => HVC_input"]
-        
+
         # carbon cycles via bio daccu feedstocks
         flw["feeddaccu => HVC_input"][...] = aux["total_primary_HVC"] * prm["daccu_production_rate"]
         flw["feedbio => HVC_input"][...] = aux["total_primary_HVC"] * prm["bio_production_rate"]
-        
+
         # captured emissions and ccu feedstocks
         # non-C atmosphere & captured has no meaning & is equivalent to sysenv
         flw["emission => captured"][...] = (flw["incineration => emission"] + flw["reclchem => emission"]) * prm["emission_capture_rate"]

--- a/remind_mfa/plastics/plastics_mfa_system.py
+++ b/remind_mfa/plastics/plastics_mfa_system.py
@@ -63,10 +63,12 @@ class PlasticsMFASystemFuture(CommonMFASystem):
 
         aux = {
             "total_primary_fabrication": self.get_new_array(dim_letters=("t", "e", "r", "m")),
-            "total_primary_virgin": self.get_new_array(dim_letters=("t", "e", "r")),
+            "total_polymerization_feed": self.get_new_array(dim_letters=("t", "e", "r", "m")),
+            "total_primary_HVC": self.get_new_array(dim_letters=("t", "e", "r")),
             "total_waste_collected": self.get_new_array(dim_letters=("t", "e", "r", "m")),
             "reclmech_loss": self.get_new_array(dim_letters=("t", "e", "r", "m")),
-            "virgin_ratio_nonc_to_c": self.get_new_array(dim_letters=("t", "r")),
+            "HVC_c_content": self.get_new_array(dim_letters=("t", "e", "r")),
+            "HVC_ratio_nonc_to_c": self.get_new_array(dim_letters=("t", "r")),
         }
 
         # fmt: off
@@ -89,9 +91,7 @@ class PlasticsMFASystemFuture(CommonMFASystem):
         flw["reclmech => incineration"][...] = aux["reclmech_loss"] - flw["reclmech => uncontrolled"]
 
         flw["collected => reclchem"][...] = aux["total_waste_collected"] * prm["chemical_recycling_rate"]
-        flw["reclchem => virgin"][...] = flw["collected => reclchem"] * prm["chemical_recycling_yield"]
-        flw["reclchem => emission"][...] = flw["collected => reclchem"] - flw["reclchem => virgin"]
-
+        
         flw["collected => incineration"][...] = aux["total_waste_collected"] * prm["incineration_rate"]
         flw["incineration => emission"][...] = flw["collected => incineration"] + flw["reclmech => incineration"]
 
@@ -104,11 +104,6 @@ class PlasticsMFASystemFuture(CommonMFASystem):
 
         flw["eol => mismanaged"][...] = flw["use => eol"] - flw["eol => collected"]
         flw["mismanaged => uncontrolled"][...] = flw["eol => mismanaged"]
-
-        # non-C atmosphere & captured has no meaning & is equivalent to sysenv
-        flw["emission => captured"][...] = (flw["incineration => emission"] + flw["reclchem => emission"]) * prm["emission_capture_rate"]
-        flw["emission => atmosphere"][...] = flw["incineration => emission"] + flw["reclchem => emission"] - flw["emission => captured"]
-        flw["captured => virginccu"][...] = flw["emission => captured"]
 
         # now trades and production flows are computed starting from the stock inflow
         flw["good_market => use"][...] = stk["in_use"].inflow
@@ -148,33 +143,51 @@ class PlasticsMFASystemFuture(CommonMFASystem):
         )
         flw["primary_market => fabrication"][...] = aux["total_primary_fabrication"]
 
-        flw["virgin => primary_market"][...] = (
+        flw["polymerization => primary_market"][...] = (
             flw["primary_market => fabrication"]
             - flw["imports => primary_market"]
             + flw["primary_market => exports"]
         )
 
-        aux["total_primary_virgin"][...] = flw["virgin => primary_market"] - flw["reclchem => virgin"]
-        flw["virgindaccu => virgin"][...] = aux["total_primary_virgin"] * prm["daccu_production_rate"]
-        flw["virginbio => virgin"][...] = aux["total_primary_virgin"] * prm["bio_production_rate"]
+        aux["total_polymerization_feed"][...] = flw["polymerization => primary_market"] / prm["polymerization_yield"]
+        flw["polymerization => losses"][...] = aux["total_polymerization_feed"] - flw["polymerization => primary_market"]
+        flw["losses => sysenv"][...] = flw["polymerization => losses"]
+        flw["HVC_input => polymerization"][...] = aux["total_polymerization_feed"].sum_to(("t", "r", "m")) * prm["HVC_input_ratio"]
+        flw["C4_input => polymerization"][...] = aux["total_polymerization_feed"].sum_to(("t", "r", "m")) * prm["C4_input_ratio"]
+        flw["other_reactants => polymerization"][...] = aux["total_polymerization_feed"] - flw["HVC_input => polymerization"] - flw["C4_input => polymerization"]
+        aux["HVC_c_content"][...] = flw["HVC_input => polymerization"] / flw["HVC_input => polymerization"].sum_to(("t", "r"))
 
-        # since non-C captured has no meaning & is equivalent to sysenv, non-C of virgin CCU production has to be calculated based on the same ratio as in overall virgin production
-        aux["virgin_ratio_nonc_to_c"][...] = aux["total_primary_virgin"]["Other Elements"] / aux["total_primary_virgin"]["C"]
-        flw["virginccu => virgin"]["C"] = flw["captured => virginccu"]["C"]
-        flw["virginccu => virgin"]["Other Elements"] = flw["virginccu => virgin"]["C"] * aux["virgin_ratio_nonc_to_c"]
-
-        flw["virginfoss => virgin"][...] = (
-            flw["virgin => primary_market"]
-            - flw["virgindaccu => virgin"]
-            - flw["virginbio => virgin"]
-            - flw["virginccu => virgin"]
-            - flw["reclchem => virgin"]
+        # chemical recycling
+        flw["reclchem => HVC_input"][...] = flw["collected => reclchem"].sum_to(("t", "r")) * aux["HVC_c_content"] * prm["chemical_recycling_yield"] # TODO: differentiate yield by element instead of using C content of HVC!
+        flw["reclchem => emission"][...] = flw["collected => reclchem"] - flw["reclchem => HVC_input"]
+        aux["total_primary_HVC"][...] = flw["HVC_input => polymerization"] - flw["reclchem => HVC_input"]
+        
+        # carbon cycles via bio daccu feedstocks
+        flw["feeddaccu => HVC_input"][...] = aux["total_primary_HVC"] * prm["daccu_production_rate"]
+        flw["feedbio => HVC_input"][...] = aux["total_primary_HVC"] * prm["bio_production_rate"]
+        
+        # captured emissions and ccu feedstocks
+        # non-C atmosphere & captured has no meaning & is equivalent to sysenv
+        flw["emission => captured"][...] = (flw["incineration => emission"] + flw["reclchem => emission"]) * prm["emission_capture_rate"]
+        flw["emission => atmosphere"][...] = flw["incineration => emission"] + flw["reclchem => emission"] - flw["emission => captured"]
+        flw["captured => feedccu"][...] = flw["emission => captured"]
+        # non-C of CCU HVC production has to be calculated based on the same ratio as in overall HVC production
+        aux["HVC_ratio_nonc_to_c"][...] = aux["total_primary_HVC"]["Other Elements"] / aux["total_primary_HVC"]["C"]
+        flw["feedccu => HVC_input"]["C"] = flw["captured => feedccu"]["C"]
+        flw["feedccu => HVC_input"]["Other Elements"] = flw["feedccu => HVC_input"]["C"] * aux["HVC_ratio_nonc_to_c"]
+        flw["feedfoss => HVC_input"][...] = (
+            aux["total_primary_HVC"]
+            - flw["feeddaccu => HVC_input"]
+            - flw["feedbio => HVC_input"]
+            - flw["feedccu => HVC_input"]
         )
 
-        flw["sysenv => virginfoss"][...] = flw["virginfoss => virgin"]
-        flw["atmosphere => virginbio"][...] = flw["virginbio => virgin"]
-        flw["atmosphere => virgindaccu"][...] = flw["virgindaccu => virgin"]
-        flw["sysenv => virginccu"][...] = flw["virginccu => virgin"] - flw["captured => virginccu"]
+        flw["sysenv => C4_input"][...] = flw["C4_input => polymerization"]
+        flw["sysenv => other_reactants"][...] = flw["other_reactants => polymerization"]
+        flw["sysenv => feedfoss"][...] = flw["feedfoss => HVC_input"]
+        flw["atmosphere => feedbio"][...] = flw["feedbio => HVC_input"]
+        flw["atmosphere => feeddaccu"][...] = flw["feeddaccu => HVC_input"]
+        flw["sysenv => feedccu"][...] = flw["feedccu => HVC_input"] - flw["captured => feedccu"]
         flw["sysenv => imports"][...] = flw["imports => good_market"] + flw["imports => primary_market"] + flw["imports => waste_market"]
         flw["exports => sysenv"][...] = flw["good_market => exports"] + flw["primary_market => exports"] + flw["waste_market => exports"]
 
@@ -195,6 +208,6 @@ class PlasticsMFASystemFuture(CommonMFASystem):
 
         stk["atmospheric"].inflow[...] = flw["emission => atmosphere"]
         stk["atmospheric"].outflow[...] = (
-            flw["atmosphere => virgindaccu"] + flw["atmosphere => virginbio"]
+            flw["atmosphere => feeddaccu"] + flw["atmosphere => feedbio"]
         )
         stk["atmospheric"].compute()

--- a/remind_mfa/plastics/plastics_visualization.py
+++ b/remind_mfa/plastics/plastics_visualization.py
@@ -282,7 +282,7 @@ class PlasticsVisualizer(CommonVisualizer):
             {
                 fn: emission_color
                 for fn, f in mfa.flows.items()
-                if f.to_process.name in ("atmosphere", "mismanaged", "uncontrolled", "emission")
+                if f.to_process.name in ("atmosphere", "mismanaged", "uncontrolled", "emission", "losses")
             }
         )
 

--- a/remind_mfa/plastics/plastics_visualization.py
+++ b/remind_mfa/plastics/plastics_visualization.py
@@ -282,7 +282,8 @@ class PlasticsVisualizer(CommonVisualizer):
             {
                 fn: emission_color
                 for fn, f in mfa.flows.items()
-                if f.to_process.name in ("atmosphere", "mismanaged", "uncontrolled", "emission", "losses")
+                if f.to_process.name
+                in ("atmosphere", "mismanaged", "uncontrolled", "emission", "losses")
             }
         )
 


### PR DESCRIPTION
This PR introduces a translation from plastics to HVC input, using input data from https://github.com/pik-piam/mrmfa/pull/54.
- The virgin process is renamed to polymerization. 
- The new polymerization yield parameter determines the total input into the polymerization process and losses.
- The total input into the polymerization process is split into HVC (w/o C4, because we do not account for C4 in REMIND), C4 and other reactants inputs (these are new processes) by two other new parameters (HVC and C4 input ratio). The remaining share of input is other reactants. 
- Chemical recycling now feeds into the new HVC input process. Hence, polymerization losses are now also accounted for here. For now, it is assumed that the carbon content of the HVC from chemical recycling is the same as of HVC going into polymerization, since the chemical recycling yield does not differentiate by material and element.
- For better understandability, the HVC feedstocks (fossil, ccu, daccu, bio) are renamed from virginXXX to feedXXX.