### PR TITLE
Allow trade of recycled plastic polymers

### DIFF
--- a/remind_mfa/plastics/plastics_definition.py
+++ b/remind_mfa/plastics/plastics_definition.py
@@ -109,7 +109,7 @@ def get_plastics_definition(cfg: PlasticsCfg, historic: bool) -> RemindMFADefini
             fd.FlowDefinition(from_process="collected", to_process="landfill", dim_letters=("t","e","r","m")),
             fd.FlowDefinition(from_process="collected", to_process="incineration", dim_letters=("t","e","r","m")),
             fd.FlowDefinition(from_process="mismanaged", to_process="uncontrolled", dim_letters=("t","e","r","m")),
-            fd.FlowDefinition(from_process="reclmech", to_process="fabrication", dim_letters=("t","e","r","m")),
+            fd.FlowDefinition(from_process="reclmech", to_process="primary_market", dim_letters=("t","e","r","m")),
             fd.FlowDefinition(from_process="reclchem", to_process="HVC_input", dim_letters=("t","e","r")),
             fd.FlowDefinition(from_process="reclchem", to_process="emission", dim_letters=("t","e","r")),
             fd.FlowDefinition(from_process="reclmech", to_process="uncontrolled", dim_letters=("t","e","r","m")),

--- a/remind_mfa/plastics/plastics_export.py
+++ b/remind_mfa/plastics/plastics_export.py
@@ -73,7 +73,7 @@ class PlasticsDataExporter(CommonDataExporter):
             **constants,
         )
         ## secondary production
-        prod_recl = mfa.flows["reclmech => fabrication"] + mfa.flows["reclchem => HVC_input"]
+        prod_recl = mfa.flows["reclmech => primary_market"] + mfa.flows["reclchem => HVC_input"]
         prod_recl_df = self.to_iamc_df(prod_recl.sum_to(("t", "r")))
         prod_recl_idf = pyam.IamDataFrame(
             prod_recl_df,

--- a/remind_mfa/plastics/plastics_mfa_system.py
+++ b/remind_mfa/plastics/plastics_mfa_system.py
@@ -64,7 +64,7 @@ class PlasticsMFASystemFuture(CommonMFASystem):
         trd = self.trade_set
 
         aux = {
-            "secondary_excess": self.get_new_array(dim_letters=("t", "e", "r", "m")),
+            "secondary_excess": self.get_new_array(dim_letters=("t", "r", "m")),
             "net_other_polymerization_input": self.get_new_array(dim_letters=("t", "e", "r")),
             "upstream_losses": self.get_new_array(dim_letters=("t", "e", "r")),
             "total_polymerization_feed": self.get_new_array(dim_letters=("t", "e", "r", "m")),
@@ -142,16 +142,29 @@ class PlasticsMFASystemFuture(CommonMFASystem):
             future_dom_demand=flw["primary_market => fabrication"],
         )
         extrapolator.run()
-        # net exports of plastics should be at least the secondary production from mechanical recycling minus domestic plastics demand 
-        aux["secondary_excess"] = flw["reclmech => primary_market"] - flw["primary_market => fabrication"] - trd["primary"].net_exports
-        if np.any(aux["secondary_excess"].values > 0):
-            message = f"There is more secondary plastics available than used! Items:"
-            indices = aux["secondary_excess"].items_where(lambda x: x > 0)
-            for index in indices:
-                message += "\n  " + ", ".join(index)
-            logging.warning(message + "\n Imports of primary plastics are scaled down and exports are scaled up by 0.5*the excess.")
-            trd["primary"].imports[...] = trd["primary"].imports - aux["secondary_excess"].maximum(0)*0.5
-            trd["primary"].exports[...] = trd["primary"].exports + aux["secondary_excess"].maximum(0)*0.5
+        # net exports of plastics should be at least the secondary production from mechanical recycling minus domestic plastics demand.
+        # balance() applies global scaling that partially undoes the per-region correction, so we iterate until the excess is gone.
+        for iteration in range(20):
+            aux["secondary_excess"][...] = (
+                flw["reclmech => primary_market"] - flw["primary_market => fabrication"] - trd["primary"].net_exports
+            )
+            excess = aux["secondary_excess"].maximum(0)
+            if not np.any(excess.values > 1e-6):
+                break
+            if iteration == 0:
+                message = "There is more secondary plastics available than used! Items:"
+                indices = aux["secondary_excess"].items_where(lambda x: x > 0)
+                for index in indices:
+                    message += "\n  " + ", ".join(index)
+                logging.warning(message + "\n Iteratively scaling down primary imports and scaling up primary exports.")
+            # Reduce imports first (cap at 0), increase exports for any remaining excess.
+            import_reduction = excess.minimum(trd["primary"].imports)
+            trd["primary"].imports[...] = trd["primary"].imports - import_reduction
+            trd["primary"].exports[...] = trd["primary"].exports + (excess - import_reduction)
+            # balance() restores global trade balance but partially dilutes the regional fix → hence the loop.
+            trd["primary"].balance()
+        else:
+            logging.warning("Secondary excess in primary plastics trade did not converge after 20 iterations.")
 
         flw["primary_market => exports"][...] = (
             trd["primary"].exports * self.parameters["carbon_content_materials"]

--- a/remind_mfa/plastics/plastics_mfa_system.py
+++ b/remind_mfa/plastics/plastics_mfa_system.py
@@ -233,7 +233,9 @@ class PlasticsMFASystemFuture(CommonMFASystem):
                 message = "There is more secondary plastics available than used! Items:"
                 for index in secondary_excess.items_where(lambda x: x > 0):
                     message += "\n  " + ", ".join(index)
-                logging.warning(message + "\n Iteratively adjusting primary trade to absorb secondary excess.")
+                logging.warning(
+                    message + "\n Iteratively adjusting primary trade to absorb secondary excess."
+                )
             total_trade = trd["primary"].imports + trd["primary"].exports
             import_share = trd["primary"].imports / total_trade.maximum(np.finfo(float).eps)
             import_reduction = (excess * import_share).minimum(trd["primary"].imports)
@@ -242,7 +244,9 @@ class PlasticsMFASystemFuture(CommonMFASystem):
             # balance() restores global trade balance but partially dilutes the regional fix → hence the loop.
             trd["primary"].balance()
         else:
-            logging.warning("Secondary excess in primary plastics trade did not converge after 20 iterations.")
+            logging.warning(
+                "Secondary excess in primary plastics trade did not converge after 20 iterations."
+            )
 
     def compute_other_stocks(self):
 

--- a/remind_mfa/plastics/plastics_mfa_system.py
+++ b/remind_mfa/plastics/plastics_mfa_system.py
@@ -64,7 +64,6 @@ class PlasticsMFASystemFuture(CommonMFASystem):
         trd = self.trade_set
 
         aux = {
-            "secondary_excess": self.get_new_array(dim_letters=("t", "r", "m")),
             "net_other_polymerization_input": self.get_new_array(dim_letters=("t", "e", "r")),
             "upstream_losses": self.get_new_array(dim_letters=("t", "e", "r")),
             "total_polymerization_feed": self.get_new_array(dim_letters=("t", "e", "r", "m")),
@@ -143,28 +142,7 @@ class PlasticsMFASystemFuture(CommonMFASystem):
         )
         extrapolator.run()
         # net exports of plastics should be at least the secondary production from mechanical recycling minus domestic plastics demand.
-        # balance() applies global scaling that partially undoes the per-region correction, so we iterate until the excess is gone.
-        for iteration in range(20):
-            aux["secondary_excess"][...] = (
-                flw["reclmech => primary_market"] - flw["primary_market => fabrication"] - trd["primary"].net_exports
-            )
-            excess = aux["secondary_excess"].maximum(0)
-            if not np.any(excess.values > 1e-6):
-                break
-            if iteration == 0:
-                message = "There is more secondary plastics available than used! Items:"
-                indices = aux["secondary_excess"].items_where(lambda x: x > 0)
-                for index in indices:
-                    message += "\n  " + ", ".join(index)
-                logging.warning(message + "\n Iteratively scaling down primary imports and scaling up primary exports.")
-            # Reduce imports first (cap at 0), increase exports for any remaining excess.
-            import_reduction = excess.minimum(trd["primary"].imports)
-            trd["primary"].imports[...] = trd["primary"].imports - import_reduction
-            trd["primary"].exports[...] = trd["primary"].exports + (excess - import_reduction)
-            # balance() restores global trade balance but partially dilutes the regional fix → hence the loop.
-            trd["primary"].balance()
-        else:
-            logging.warning("Secondary excess in primary plastics trade did not converge after 20 iterations.")
+        self._adjust_primary_trade_for_secondary_excess(flw, trd)
 
         flw["primary_market => exports"][...] = (
             trd["primary"].exports * self.parameters["carbon_content_materials"]
@@ -225,6 +203,46 @@ class PlasticsMFASystemFuture(CommonMFASystem):
         flw["exports => sysenv"][...] = flw["good_market => exports"] + flw["primary_market => exports"] + flw["waste_market => exports"]
 
         # fmt: on
+
+    def _adjust_primary_trade_for_secondary_excess(self, flw, trd):
+        """
+        Iteratively adjust primary plastics trade so that no region has more
+        secondary material available than its primary demand plus net exports.
+
+        Each iteration splits the per-region excess between an import reduction
+        and an export increase proportional to each region's share of total trade:
+            import share  = imports  / (imports + exports)
+            export share  = exports  / (imports + exports)
+
+        balance() is called after every adjustment to restore global trade
+        balance, which partially re-introduces a residual excess — hence the
+        loop.  Convergence is guaranteed because each iteration strictly
+        reduces the excess.
+        """
+        secondary_excess = self.get_new_array(dim_letters=("t", "r", "m"))
+        for iteration in range(20):
+            secondary_excess[...] = (
+                flw["reclmech => primary_market"]
+                - flw["primary_market => fabrication"]
+                - trd["primary"].net_exports
+            )
+            excess = secondary_excess.maximum(0)
+            if not np.any(excess.values > 1e-6):
+                break
+            if iteration == 0:
+                message = "There is more secondary plastics available than used! Items:"
+                for index in secondary_excess.items_where(lambda x: x > 0):
+                    message += "\n  " + ", ".join(index)
+                logging.warning(message + "\n Iteratively adjusting primary trade to absorb secondary excess.")
+            total_trade = trd["primary"].imports + trd["primary"].exports
+            import_share = trd["primary"].imports / total_trade.maximum(np.finfo(float).eps)
+            import_reduction = (excess * import_share).minimum(trd["primary"].imports)
+            trd["primary"].imports[...] = trd["primary"].imports - import_reduction
+            trd["primary"].exports[...] = trd["primary"].exports + (excess - import_reduction)
+            # balance() restores global trade balance but partially dilutes the regional fix → hence the loop.
+            trd["primary"].balance()
+        else:
+            logging.warning("Secondary excess in primary plastics trade did not converge after 20 iterations.")
 
     def compute_other_stocks(self):
 

--- a/remind_mfa/plastics/plastics_mfa_system.py
+++ b/remind_mfa/plastics/plastics_mfa_system.py
@@ -1,4 +1,6 @@
 import flodym as fd
+import numpy as np
+import logging
 
 from remind_mfa.common.common_mfa_system import CommonMFASystem
 from remind_mfa.common.trade import TradeSet
@@ -62,6 +64,7 @@ class PlasticsMFASystemFuture(CommonMFASystem):
         trd = self.trade_set
 
         aux = {
+            "secondary_excess": self.get_new_array(dim_letters=("t", "e", "r", "m")),
             "net_other_polymerization_input": self.get_new_array(dim_letters=("t", "e", "r")),
             "upstream_losses": self.get_new_array(dim_letters=("t", "e", "r")),
             "total_polymerization_feed": self.get_new_array(dim_letters=("t", "e", "r", "m")),
@@ -89,9 +92,9 @@ class PlasticsMFASystemFuture(CommonMFASystem):
 
         aux["total_waste_collected"][...] = flw["eol => collected"] + flw["waste_market => collected"] - flw["collected => waste_market"]
         flw["collected => reclmech"][...] = aux["total_waste_collected"] * prm["mechanical_recycling_rate"]
-        flw["reclmech => fabrication"][...] = flw["collected => reclmech"] * prm["mechanical_recycling_yield"]
-        flw["reclmech => fabrication"]["Elastomers (tyres)"] = 0 # FIXME hot fix to avoid negative flows in virgin production; will be fixed once recycling rate has a material dimension
-        aux["reclmech_loss"][...] = flw["collected => reclmech"] - flw["reclmech => fabrication"]
+        flw["collected => reclmech"]["Elastomers (tyres)"] = 0 # FIXME hot fix to avoid negative flows in virgin production; will be fixed once recycling rate has a material dimension
+        flw["reclmech => primary_market"][...] = flw["collected => reclmech"] * prm["mechanical_recycling_yield"]
+        aux["reclmech_loss"][...] = flw["collected => reclmech"] - flw["reclmech => primary_market"]
         flw["reclmech => uncontrolled"][...] = aux["reclmech_loss"] * prm["reclmech_loss_uncontrolled_rate"]
         flw["reclmech => incineration"][...] = aux["reclmech_loss"] - flw["reclmech => uncontrolled"]
 
@@ -128,8 +131,8 @@ class PlasticsMFASystemFuture(CommonMFASystem):
         )
         flw["fabrication => good_market"][...] = flw["good_market => use"] - flw["imports => good_market"] + flw["good_market => exports"]
 
-        # imports of primary plastics cannot exceed primary plastics demand in fabrication (plastics fabrication - mechanically recycled plastics)
-        flw["primary_market => fabrication"][...] = flw["fabrication => good_market"] - flw["reclmech => fabrication"]
+        # imports of primary plastics cannot exceed primary plastics demand in fabrication
+        flw["primary_market => fabrication"][...] = flw["fabrication => good_market"]
         historic_trade["primary_his"].imports[...] = historic_trade["primary_his"].imports.minimum(flw["primary_market => fabrication"][{"t": self.dims["h"]}])
         historic_trade["primary_his"].balance(to="minimum")
 
@@ -139,6 +142,16 @@ class PlasticsMFASystemFuture(CommonMFASystem):
             future_dom_demand=flw["primary_market => fabrication"],
         )
         extrapolator.run()
+        # net exports of plastics should be at least the secondary production from mechanical recycling minus domestic plastics demand 
+        aux["secondary_excess"] = flw["reclmech => primary_market"] - flw["primary_market => fabrication"] - trd["primary"].net_exports
+        if np.any(aux["secondary_excess"].values > 0):
+            message = f"There is more secondary plastics available than used! Items:"
+            indices = aux["secondary_excess"].items_where(lambda x: x > 0)
+            for index in indices:
+                message += "\n  " + ", ".join(index)
+            logging.warning(message + "\n Imports of primary plastics are scaled down and exports are scaled up by 0.5*the excess.")
+            trd["primary"].imports[...] = trd["primary"].imports - aux["secondary_excess"].maximum(0)*0.5
+            trd["primary"].exports[...] = trd["primary"].exports + aux["secondary_excess"].maximum(0)*0.5
 
         flw["primary_market => exports"][...] = (
             trd["primary"].exports * self.parameters["carbon_content_materials"]
@@ -151,6 +164,7 @@ class PlasticsMFASystemFuture(CommonMFASystem):
             flw["primary_market => fabrication"]
             - flw["imports => primary_market"]
             + flw["primary_market => exports"]
+            - flw["reclmech => primary_market"]
         )
 
         aux["total_polymerization_feed"][...] = flw["polymerization => primary_market"] / prm["polymerization_yield"]

--- a/remind_mfa/plastics/plastics_visualization.py
+++ b/remind_mfa/plastics/plastics_visualization.py
@@ -41,13 +41,10 @@ class PlasticsVisualizer(CommonVisualizer):
                 name="Primary production",
                 linecolor_dim="Material",
             )
-            self.visualize_fdarr_stacked(
+            self.visualize_fdarr(
                 mfa=model.future_mfa,
-                flow=(
-                    model.future_mfa.flows["polymerization => primary_market"]
-                    - model.future_mfa.flows["primary_market => exports"]
-                ),
-                name="Primary production for domestic market",
+                flow=model.future_mfa.flows["polymerization => primary_market"],
+                name="Primary production",
                 linecolor_dim="Material",
             )
             self.visualize_fdarr_stacked(
@@ -64,22 +61,13 @@ class PlasticsVisualizer(CommonVisualizer):
             )
             self.visualize_fdarr_stacked(
                 mfa=model.future_mfa,
-                flow=(
-                    model.future_mfa.flows["fabrication => good_market"]
-                    - model.future_mfa.flows["good_market => exports"]
-                ),
-                name="Fabrication for domestic market",
-                linecolor_dim="Material",
-            )
-            self.visualize_fdarr_stacked(
-                mfa=model.future_mfa,
                 flow=model.future_mfa.stocks["in_use"].inflow,
                 name="Demand",
                 linecolor_dim="Material",
             )
             self.visualize_fdarr_stacked(
                 mfa=model.future_mfa,
-                flow=model.future_mfa.flows["reclmech => fabrication"],
+                flow=model.future_mfa.flows["reclmech => primary_market"],
                 name="Mechanically recycled",
                 linecolor_dim="Material",
             )


### PR DESCRIPTION
Previously, recycled plastics were directly going to plastics fabrication, implying that all recycled plastics are used within a region. To account for the fact that also recycled granulate is traded, I now route the mechanically recycled plastics flow to primary market. This lead to the problem that more recycled plastics were available than the plastics supply resulting from the primary trade extrapolation for some polymers within some regions. Assuming that this oversupply of recycled plastics will lead to either increased exports or decreased imports, I corrected the respective primary trade (using an iteration to ensure global trade balancing).