### PR TITLE
refactor: iamc export

### DIFF
--- a/remind_mfa/cement/cement_export.py
+++ b/remind_mfa/cement/cement_export.py
@@ -1,120 +1,47 @@
-import pyam
-import flodym as fd
-
-from remind_mfa.common.common_export import CommonDataExporter
+from remind_mfa.common.common_export import CommonDataExporter, IamcVariable
 
 
 class CementDataExporter(CommonDataExporter):
-    def write_iamc(self, mfa: fd.MFASystem):
 
-        model = "REMIND 3.0"
-        scenario = "SSP2_NPi"
-        constants = {"model": model, "scenario": scenario}
-
-        reported_dims = ("t", "r", "s")
-
-        # cement production
-        cement_prod_by_stock_type = (
-            mfa.flows["prod_cement => market_cement"] + mfa.flows["prod_cement => sysenv"]
-        )
-        prod_df = self.to_iamc_df(cement_prod_by_stock_type)
-        prod_df["variable"] = "Production|Non-Metallic Minerals|Cement"
-        cement_prod_idf = pyam.IamDataFrame(
-            prod_df,
-            unit="t/yr",
-            **constants,
-        )
-        cement_prod_idf.aggregate(
-            variable="Production|Non-Metallic Minerals|Cement",
-            append=True,
-        )
-
-        # clinker production
-        clinker_prod_by_stock_type = (
-            mfa.flows["prod_clinker => market_clinker"] + mfa.flows["prod_clinker => sysenv"]
-        )
-        clinker_prod_df = self.to_iamc_df(clinker_prod_by_stock_type)
-        clinker_prod_df["variable"] = "Production|Non-Metallic Minerals|Cement Clinker"
-        clinker_prod_idf = pyam.IamDataFrame(
-            clinker_prod_df,
-            unit="t/yr",
-            **constants,
-        )
-        clinker_prod_idf.aggregate(
-            variable="Production|Non-Metallic Minerals|Cement Clinker",
-            append=True,
-        )
-
-        # cement demand
-        cement_demand_by_stock_type = mfa.flows["market_cement => prod_product"].sum_to(
-            reported_dims
-        )
-        demand_df = self.to_iamc_df(cement_demand_by_stock_type)
-        demand_df["variable"] = (
-            "Material Demand|Non-Metallic Minerals|Cement|" + demand_df["Stock Type"]
-        )
-        demand_df = demand_df.drop(columns=["Stock Type"])
-        demand_idf = pyam.IamDataFrame(
-            demand_df,
-            unit="t/yr",
-            **constants,
-        )
-        demand_idf.aggregate(
-            variable="Material Demand|Non-Metallic Minerals|Cement",
-            append=True,
-        )
-
-        # cement stocks
-        cement_stock_by_stock_type = (
-            mfa.stocks["in_use"].stock[{"k": "cement"}].sum_to(reported_dims)
-        )
-        stock_df = self.to_iamc_df(cement_stock_by_stock_type)
-        stock_df["variable"] = (
-            "Material Stock|Non-Metallic Minerals|Cement|" + stock_df["Stock Type"]
-        )
-        stock_df = stock_df.drop(columns=["Stock Type"])
-        stock_idf = pyam.IamDataFrame(
-            stock_df,
-            unit="t",
-            **constants,
-        )
-        stock_idf.aggregate(
-            variable="Material Stock|Non-Metallic Minerals|Cement",
-            append=True,
-        )
-
-        # cement eol
-        cement_scrap_by_stock_type = (
-            mfa.stocks["in_use"].outflow[{"k": "cement"}].sum_to(reported_dims)
-        )
-        scrap_df = self.to_iamc_df(cement_scrap_by_stock_type)
-        scrap_df["variable"] = "Scrap|Non-Metallic Minerals|Cement|" + scrap_df["Stock Type"]
-        scrap_df = scrap_df.drop(columns=["Stock Type"])
-        scrap_idf = pyam.IamDataFrame(
-            scrap_df,
-            unit="t/yr",
-            **constants,
-        )
-        scrap_idf.aggregate(
-            variable="Scrap|Non-Metallic Minerals|Cement",
-            append=True,
-        )
-
-        idf = pyam.concat(
-            [
-                cement_prod_idf,
-                clinker_prod_idf,
-                demand_idf,
-                stock_idf,
-                scrap_idf,
-            ]
-        )
-        idf.aggregate_region(
-            variable=idf.variable,
-            region="World",
-            append=True,
-        )
-        idf.convert_unit(current="t/yr", to="Mt/yr", inplace=True)
-        idf.convert_unit(current="t", to="Mt", inplace=True)
-
-        idf.to_excel(self.export_path("iamc", f"output_iamc.xlsx"))
+    def iamc_variables(self) -> list[IamcVariable]:
+        return [
+            IamcVariable(
+                variable="Production|Non-Metallic Minerals|Cement",
+                getter=lambda mfa: (
+                    mfa.flows["prod_cement => market_cement"] + mfa.flows["prod_cement => sysenv"]
+                ).sum_to(("t", "r")),
+                unit="t/yr",
+            ),
+            IamcVariable(
+                variable="Production|Non-Metallic Minerals|Cement Clinker",
+                getter=lambda mfa: (
+                    mfa.flows["prod_clinker => market_clinker"]
+                    + mfa.flows["prod_clinker => sysenv"]
+                ).sum_to(("t", "r")),
+                unit="t/yr",
+            ),
+            IamcVariable(
+                variable="Material Demand|Non-Metallic Minerals|Cement",
+                getter=lambda mfa: mfa.flows["market_cement => prod_product"].sum_to(
+                    ("t", "r", "s")
+                ),
+                unit="t/yr",
+                per="Stock Type",
+            ),
+            IamcVariable(
+                variable="Material Stock|Non-Metallic Minerals|Cement",
+                getter=lambda mfa: mfa.stocks["in_use"]
+                .stock[{"k": "cement"}]
+                .sum_to(("t", "r", "s")),
+                unit="t",
+                per="Stock Type",
+            ),
+            IamcVariable(
+                variable="Scrap|Non-Metallic Minerals|Cement",
+                getter=lambda mfa: (
+                    mfa.stocks["in_use"].outflow[{"k": "cement"}].sum_to(("t", "r", "s"))
+                ),
+                unit="t/yr",
+                per="Stock Type",
+            ),
+        ]

--- a/remind_mfa/cement/cement_export.py
+++ b/remind_mfa/cement/cement_export.py
@@ -6,14 +6,14 @@ class CementDataExporter(CommonDataExporter):
     def iamc_variables(self) -> list[IamcVariable]:
         return [
             IamcVariable(
-                variable_name="Production|Non-Metallic Minerals|Cement", # PRISMA nomenclature
+                variable_name="Production|Non-Metallic Minerals|Cement",  # PRISMA nomenclature
                 calculation_function=lambda mfa: (
                     mfa.flows["prod_cement => market_cement"] + mfa.flows["prod_cement => sysenv"]
                 ).sum_to(("t", "r")),
                 unit="t/yr",
             ),
             IamcVariable(
-                variable_name="Production|Non-Metallic Minerals|Cement Clinker", # PRISMA nomenclature
+                variable_name="Production|Non-Metallic Minerals|Cement Clinker",  # PRISMA nomenclature
                 calculation_function=lambda mfa: (
                     mfa.flows["prod_clinker => market_clinker"]
                     + mfa.flows["prod_clinker => sysenv"]
@@ -21,7 +21,7 @@ class CementDataExporter(CommonDataExporter):
                 unit="t/yr",
             ),
             IamcVariable(
-                variable_name="Material Demand|Non-Metallic Minerals|Cement", # PRISMA nomenclature
+                variable_name="Material Demand|Non-Metallic Minerals|Cement",  # PRISMA nomenclature
                 calculation_function=lambda mfa: mfa.flows["market_cement => prod_product"].sum_to(
                     ("t", "r", "s")
                 ),
@@ -29,7 +29,7 @@ class CementDataExporter(CommonDataExporter):
                 split_name="Stock Type",
             ),
             IamcVariable(
-                variable_name="Material Stock|Non-Metallic Minerals|Cement", # PRISMA nomenclature
+                variable_name="Material Stock|Non-Metallic Minerals|Cement",  # PRISMA nomenclature
                 calculation_function=lambda mfa: mfa.stocks["in_use"]
                 .stock[{"k": "cement"}]
                 .sum_to(("t", "r", "s")),
@@ -37,7 +37,7 @@ class CementDataExporter(CommonDataExporter):
                 split_name="Stock Type",
             ),
             IamcVariable(
-                variable_name="Scrap|Non-Metallic Minerals|Cement", # PRISMA nomenclature
+                variable_name="Scrap|Non-Metallic Minerals|Cement",  # PRISMA nomenclature
                 calculation_function=lambda mfa: (
                     mfa.stocks["in_use"].outflow[{"k": "cement"}].sum_to(("t", "r", "s"))
                 ),

--- a/remind_mfa/cement/cement_export.py
+++ b/remind_mfa/cement/cement_export.py
@@ -6,42 +6,42 @@ class CementDataExporter(CommonDataExporter):
     def iamc_variables(self) -> list[IamcVariable]:
         return [
             IamcVariable(
-                variable="Production|Non-Metallic Minerals|Cement",
-                getter=lambda mfa: (
+                variable_name="Production|Non-Metallic Minerals|Cement",
+                calculation_function=lambda mfa: (
                     mfa.flows["prod_cement => market_cement"] + mfa.flows["prod_cement => sysenv"]
                 ).sum_to(("t", "r")),
                 unit="t/yr",
             ),
             IamcVariable(
-                variable="Production|Non-Metallic Minerals|Cement Clinker",
-                getter=lambda mfa: (
+                variable_name="Production|Non-Metallic Minerals|Cement Clinker",
+                calculation_function=lambda mfa: (
                     mfa.flows["prod_clinker => market_clinker"]
                     + mfa.flows["prod_clinker => sysenv"]
                 ).sum_to(("t", "r")),
                 unit="t/yr",
             ),
             IamcVariable(
-                variable="Material Demand|Non-Metallic Minerals|Cement",
-                getter=lambda mfa: mfa.flows["market_cement => prod_product"].sum_to(
+                variable_name="Material Demand|Non-Metallic Minerals|Cement",
+                calculation_function=lambda mfa: mfa.flows["market_cement => prod_product"].sum_to(
                     ("t", "r", "s")
                 ),
                 unit="t/yr",
-                per="Stock Type",
+                split_name="Stock Type",
             ),
             IamcVariable(
-                variable="Material Stock|Non-Metallic Minerals|Cement",
-                getter=lambda mfa: mfa.stocks["in_use"]
+                variable_name="Material Stock|Non-Metallic Minerals|Cement",
+                calculation_function=lambda mfa: mfa.stocks["in_use"]
                 .stock[{"k": "cement"}]
                 .sum_to(("t", "r", "s")),
                 unit="t",
-                per="Stock Type",
+                split_name="Stock Type",
             ),
             IamcVariable(
-                variable="Scrap|Non-Metallic Minerals|Cement",
-                getter=lambda mfa: (
+                variable_name="Scrap|Non-Metallic Minerals|Cement",
+                calculation_function=lambda mfa: (
                     mfa.stocks["in_use"].outflow[{"k": "cement"}].sum_to(("t", "r", "s"))
                 ),
                 unit="t/yr",
-                per="Stock Type",
+                split_name="Stock Type",
             ),
         ]

--- a/remind_mfa/cement/cement_export.py
+++ b/remind_mfa/cement/cement_export.py
@@ -6,14 +6,14 @@ class CementDataExporter(CommonDataExporter):
     def iamc_variables(self) -> list[IamcVariable]:
         return [
             IamcVariable(
-                variable_name="Production|Non-Metallic Minerals|Cement",
+                variable_name="Production|Non-Metallic Minerals|Cement", # PRISMA nomenclature
                 calculation_function=lambda mfa: (
                     mfa.flows["prod_cement => market_cement"] + mfa.flows["prod_cement => sysenv"]
                 ).sum_to(("t", "r")),
                 unit="t/yr",
             ),
             IamcVariable(
-                variable_name="Production|Non-Metallic Minerals|Cement Clinker",
+                variable_name="Production|Non-Metallic Minerals|Cement Clinker", # PRISMA nomenclature
                 calculation_function=lambda mfa: (
                     mfa.flows["prod_clinker => market_clinker"]
                     + mfa.flows["prod_clinker => sysenv"]
@@ -21,7 +21,7 @@ class CementDataExporter(CommonDataExporter):
                 unit="t/yr",
             ),
             IamcVariable(
-                variable_name="Material Demand|Non-Metallic Minerals|Cement",
+                variable_name="Material Demand|Non-Metallic Minerals|Cement", # PRISMA nomenclature
                 calculation_function=lambda mfa: mfa.flows["market_cement => prod_product"].sum_to(
                     ("t", "r", "s")
                 ),
@@ -29,7 +29,7 @@ class CementDataExporter(CommonDataExporter):
                 split_name="Stock Type",
             ),
             IamcVariable(
-                variable_name="Material Stock|Non-Metallic Minerals|Cement",
+                variable_name="Material Stock|Non-Metallic Minerals|Cement", # PRISMA nomenclature
                 calculation_function=lambda mfa: mfa.stocks["in_use"]
                 .stock[{"k": "cement"}]
                 .sum_to(("t", "r", "s")),
@@ -37,7 +37,7 @@ class CementDataExporter(CommonDataExporter):
                 split_name="Stock Type",
             ),
             IamcVariable(
-                variable_name="Scrap|Non-Metallic Minerals|Cement",
+                variable_name="Scrap|Non-Metallic Minerals|Cement", # PRISMA nomenclature
                 calculation_function=lambda mfa: (
                     mfa.stocks["in_use"].outflow[{"k": "cement"}].sum_to(("t", "r", "s"))
                 ),

--- a/remind_mfa/common/common_config.py
+++ b/remind_mfa/common/common_config.py
@@ -69,6 +69,33 @@ class BaseExportCfg(RemindMFABaseModel):
     """Path to export folder for this entity"""
 
 
+class IamcExportCfg(BaseExportCfg):
+    t: str = "1950:2100"
+    """Inclusive "start:stop" year range to export in IAMC format (e.g. "1950:2100")."""
+
+    @property
+    def time_items(self) -> list[int]:
+        start, stop = self._parse_range()
+        return list(range(start, stop + 1))  # inclusive of stop
+
+    def _parse_range(self) -> tuple[int, int]:
+        parts = str(self.t).split(":")
+        if len(parts) != 2:
+            raise ValueError(f"iamc.t must be a 'start:stop' year range, got {self.t!r}")
+        try:
+            start, stop = int(parts[0]), int(parts[1])
+        except ValueError:
+            raise ValueError(f"iamc.t must be a 'start:stop' year range, got {self.t!r}")
+        if start > stop:
+            raise ValueError(f"iamc.t start must not be after stop, got {self.t!r}")
+        return start, stop
+
+    @model_validator(mode="after")
+    def validate_time_range(self):
+        self._parse_range()
+        return self
+
+
 class ExportCfg(BaseExportCfg):
     csv: BaseExportCfg
     """Configuration of export to CSV files"""
@@ -78,7 +105,7 @@ class ExportCfg(BaseExportCfg):
     """Configuration of export of assumptions to a txt file."""
     docs: BaseExportCfg
     """Configuration of export to documentation files."""
-    iamc: BaseExportCfg
+    iamc: IamcExportCfg
     """Configuration of export of results in IAMC format."""
 
 

--- a/remind_mfa/common/common_export.py
+++ b/remind_mfa/common/common_export.py
@@ -163,7 +163,7 @@ class CommonDataExporter(RemindMFABaseModel):
 
         idf.convert_unit(current="t/yr", to="Mt/yr", inplace=True)
         idf.convert_unit(current="t", to="Mt", inplace=True)
-        idf.convert_unit(current="t/cap/yr", to="kg/cap/yr", factor = 1000, inplace=True)
+        idf.convert_unit(current="t/cap/yr", to="kg/cap/yr", factor=1000, inplace=True)
 
         idf.to_excel(self.export_path("iamc", "output_iamc.xlsx"))
 

--- a/remind_mfa/common/common_export.py
+++ b/remind_mfa/common/common_export.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from datetime import datetime
 from importlib.metadata import PackageNotFoundError, version
@@ -128,10 +129,12 @@ class CommonDataExporter(RemindMFABaseModel):
             return
         iamc_vars = self.common_iamc_variables() + iamc_vars
 
+        self._warn_if_iamc_includes_historic(model)
+
         mfa = model.future_mfa
         constants = {"model": self.model_name, "scenario": model.cfg.model_switches.scenario}
 
-        iamc_dataframe, split_parent_components, region_weights = self._build_iamc_dataframe(
+        iamc_dataframe, split_parent_components, region_weights = self._build_all_iamc_df(
             mfa, iamc_vars, constants
         )
 
@@ -141,10 +144,26 @@ class CommonDataExporter(RemindMFABaseModel):
 
         iamc_dataframe.to_excel(self.export_path("iamc", "output_iamc.xlsx"))
 
-    def _build_iamc_dataframe(
+    def _warn_if_iamc_includes_historic(self, model: "CommonModel"):
+        """Warn if the configured IAMC export range covers historic years.
+
+        Historic years derive partly from proprietary input data (e.g. WorldSteel), so
+        including them in a shared output risks leaking that data. The last historic year is
+        taken per-material from the model's historic time dimension.
+        """
+        last_historic_year = model.dims["h"].items[-1]
+        historic = [y for y in self.cfg.iamc.time_items if y <= last_historic_year]
+        if historic:
+            logging.warning(
+                f"IAMC export range includes historic years ({historic[0]}-{last_historic_year}), "
+                "which may derive from proprietary input data (e.g. WorldSteel). "
+                "Verify you are permitted to share these years before distributing the output."
+            )
+
+    def _build_all_iamc_df(
         self, mfa: "CommonMFASystem", iamc_vars: list, constants: dict
     ) -> tuple[pyam.IamDataFrame, dict[str, list[str]], dict[str, str]]:
-        """Build one IamDataFrame per variable spec and concatenate them.
+        """Build one IamDataFrame per iamc variable and concatenate them.
 
         Also collects two side-tables consumed by the later aggregation steps:
 
@@ -295,10 +314,8 @@ class CommonDataExporter(RemindMFABaseModel):
 
         return os.path.join(*path_tuple)
 
-    @staticmethod
-    def to_iamc_df(array: fd.FlodymArray):
-        time_items = list(range(1950, 2101))  # TODO: more flexible
-        time_out = fd.Dimension(name="Time Out", letter="O", items=time_items)
+    def to_iamc_df(self, array: fd.FlodymArray):
+        time_out = fd.Dimension(name="Time Out", letter="O", items=self.cfg.iamc.time_items)
         df = array[{"t": time_out}].to_df(dim_to_columns="Time Out", index=False)
         df = df.rename(columns={"Region": "region"})
         return df

--- a/remind_mfa/common/common_export.py
+++ b/remind_mfa/common/common_export.py
@@ -30,6 +30,9 @@ class IamcVariable(RemindMFABaseModel):
     """Base unit of the array, e.g. "t/yr" or "t"."""
     per: Optional[str] = None
     """Display-column name to split into child variables (e.g. "Good"). None = single variable."""
+    region_weight: Optional[str] = None
+    """Variable to weight by when aggregating to "World" (e.g. "Population" for per-capita
+    variables). None = plain sum across regions."""
 
 
 class CommonDataExporter(RemindMFABaseModel):
@@ -84,6 +87,20 @@ class CommonDataExporter(RemindMFABaseModel):
         except PackageNotFoundError:
             return "REMIND-MFA"
 
+    def common_iamc_variables(self) -> list[IamcVariable]:
+        """IAMC variables exported for every material.
+
+        ``Population`` is exported both as an output variable and used as the weight for
+        aggregating per-capita variables to the "World" region.
+        """
+        return [
+            IamcVariable(
+                variable="Population",
+                getter=lambda mfa: mfa.parameters["population"].sum_to(("t", "r")),
+                unit="cap",
+            ),
+        ]
+
     def iamc_variables(self) -> list[IamcVariable]:
         """Material-specific IAMC variable specifications. Override in subclasses."""
         return []
@@ -102,35 +119,66 @@ class CommonDataExporter(RemindMFABaseModel):
         specs = self.iamc_variables()
         if not specs:
             return
+        specs = self.common_iamc_variables() + specs
 
         mfa = model.future_mfa
         constants = {"model": self.model_name, "scenario": model.cfg.model_switches.scenario}
 
-        idf = pyam.concat([self._build_idf(mfa, spec, constants) for spec in specs])
+        idfs = []
+        # Map each `per` parent to the exact child variables produced by its split, so the
+        # parent is summed from those children only. Relying on pyam's default (all direct
+        # children of the parent path) would wrongly pull in sibling variables that happen to
+        # live under the same path, e.g. "…|Plastics|Per Capita".
+        per_parent_components: dict[str, list[str]] = {}
+        # Variables aggregated to "World" as a weighted mean instead of a plain sum
+        # (e.g. per-capita variables weighted by Population). Maps variable -> weight variable.
+        region_weights: dict[str, str] = {}
+        for spec in specs:
+            idf, variables = self._build_idf(mfa, spec, constants)
+            idfs.append(idf)
+            if spec.per is not None:
+                per_parent_components.setdefault(spec.variable, []).extend(variables)
+            if spec.region_weight is not None:
+                region_weights.update({v: spec.region_weight for v in variables})
+
+        idf = pyam.concat(idfs)
 
         # A `per` variable is split into children on export, so sum it back to its parent.
-        # `iamc_aggregates` adds any further parents (e.g. summing sibling variables).
-        per_parents = [spec.variable for spec in specs if spec.per is not None]
-        for parent in dict.fromkeys(per_parents + self.iamc_aggregates()):
+        for parent, components in per_parent_components.items():
+            idf.aggregate(variable=parent, components=components, append=True)
+        # `iamc_aggregates` adds any further parents whose children are separate specs
+        # (e.g. summing sibling "…|Primary" and "…|Secondary" variables).
+        for parent in self.iamc_aggregates():
+            if parent in per_parent_components:
+                continue
             idf.aggregate(variable=parent, append=True)
 
-        idf.aggregate_region(variable=idf.variable, region="World", append=True)
+        # Sum most variables across regions to "World", but aggregate per-capita (and other
+        # weighted) variables as a weight-weighted mean so, e.g., World per-capita demand is
+        # World total demand / World population rather than the sum of regional per-capita values.
+        plain_vars = [v for v in idf.variable if v not in region_weights]
+        idf.aggregate_region(variable=plain_vars, region="World", append=True)
+        for variable, weight in region_weights.items():
+            idf.aggregate_region(variable=variable, region="World", weight=weight, append=True)
 
         idf.convert_unit(current="t/yr", to="Mt/yr", inplace=True)
         idf.convert_unit(current="t", to="Mt", inplace=True)
+        idf.convert_unit(current="t/cap/yr", to="kg/cap/yr", factor = 1000, inplace=True)
 
         idf.to_excel(self.export_path("iamc", "output_iamc.xlsx"))
 
     def _build_idf(
         self, mfa: "CommonMFASystem", spec: IamcVariable, constants: dict
-    ) -> pyam.IamDataFrame:
+    ) -> tuple[pyam.IamDataFrame, list[str]]:
+        """Build the IamDataFrame for a spec and return it with the variable names it produced."""
         df = self.to_iamc_df(spec.getter(mfa))
         if spec.per is not None:
             df["variable"] = spec.variable + "|" + df[spec.per]
             df = df.drop(columns=[spec.per])
         else:
             df["variable"] = spec.variable
-        return pyam.IamDataFrame(df, unit=spec.unit, **constants)
+        variables = list(dict.fromkeys(df["variable"]))
+        return pyam.IamDataFrame(df, unit=spec.unit, **constants), variables
 
     def definition_to_markdown(self, definition: RemindMFADefinition):
 
@@ -207,7 +255,7 @@ class CommonDataExporter(RemindMFABaseModel):
 
     @staticmethod
     def to_iamc_df(array: fd.FlodymArray):
-        time_items = list(range(2025, 2101))  # TODO: more flexible
+        time_items = list(range(1950, 2101))  # TODO: more flexible
         time_out = fd.Dimension(name="Time Out", letter="O", items=time_items)
         df = array[{"t": time_out}].to_df(dim_to_columns="Time Out", index=False)
         df = df.rename(columns={"Region": "region"})

--- a/remind_mfa/common/common_export.py
+++ b/remind_mfa/common/common_export.py
@@ -129,48 +129,83 @@ class CommonDataExporter(RemindMFABaseModel):
         mfa = model.future_mfa
         constants = {"model": self.model_name, "scenario": model.cfg.model_switches.scenario}
 
+        iamc_dataframe, split_parent_components, region_weights = self._build_iamc_dataframe(
+            mfa, iamc_vars, constants
+        )
+
+        self._aggregate_iamc_variables(iamc_dataframe, split_parent_components)
+        self._aggregate_iamc_regions(iamc_dataframe, region_weights)
+        self._convert_iamc_units(iamc_dataframe)
+
+        iamc_dataframe.to_excel(self.export_path("iamc", "output_iamc.xlsx"))
+
+    def _build_iamc_dataframe(
+        self, mfa: "CommonMFASystem", iamc_vars: list, constants: dict
+    ) -> tuple[pyam.IamDataFrame, dict[str, list[str]], dict[str, str]]:
+        """Build one IamDataFrame per variable spec and concatenate them.
+
+        Also collects two side-tables consumed by the later aggregation steps:
+
+        - ``split_parent_components`` maps each ``split_name`` parent variable to the exact child
+        variables produced by its split, so the parent is summed from those children
+        only. Relying on pyam's default (all direct children of the parent path) would
+        wrongly pull in sibling variables under the same path, e.g. "…|Plastics|Per Capita".
+        - ``region_weights`` lists variables aggregated to "World" as a weighted mean
+        instead of a plain sum (e.g. per-capita variables weighted by Population),
+        mapping variable -> weight variable.
+        """
         iamc_dataframes = []
-        # Map each `per` parent to the exact child variables produced by its split, so the
-        # parent is summed from those children only. Relying on pyam's default (all direct
-        # children of the parent path) would wrongly pull in sibling variables that happen to
-        # live under the same path, e.g. "…|Plastics|Per Capita".
-        per_parent_components: dict[str, list[str]] = {}
-        # Variables aggregated to "World" as a weighted mean instead of a plain sum
-        # (e.g. per-capita variables weighted by Population). Maps variable -> weight variable.
+        split_parent_components: dict[str, list[str]] = {}
         region_weights: dict[str, str] = {}
         for iamc_var in iamc_vars:
             iamc_df, variables = self._build_iamc_df(mfa, iamc_var, constants)
             iamc_dataframes.append(iamc_df)
             if iamc_var.split_name is not None:
-                per_parent_components.setdefault(iamc_var.variable_name, []).extend(variables)
+                split_parent_components.setdefault(iamc_var.variable_name, []).extend(variables)
             if iamc_var.region_weight is not None:
                 region_weights.update({v: iamc_var.region_weight for v in variables})
+        return pyam.concat(iamc_dataframes), split_parent_components, region_weights
 
-        iamc_dataframe = pyam.concat(iamc_dataframes)
+    def _aggregate_iamc_variables(
+        self, iamc_dataframe: pyam.IamDataFrame, split_parent_components: dict[str, list[str]]
+    ):
+        """Sum child variables into their parents (variable-axis aggregation).
 
-        # A `per` variable is split into children on export, so sum it back to its parent.
-        for parent, components in per_parent_components.items():
+        Parents come from two sources:
+        - ``split_name`` variables were split into children on export, so each is summed back
+          to its parent from exactly the children it produced.
+        - ``iamc_aggregates`` adds further parents whose children are separate iamc variables
+          (e.g. summing sibling "…|Primary" and "…|Secondary" variables).
+        """
+        for parent, components in split_parent_components.items():
             iamc_dataframe.aggregate(variable=parent, components=components, append=True)
-        # `iamc_aggregates` adds any further parents whose children are separate specs
-        # (e.g. summing sibling "…|Primary" and "…|Secondary" variables).
         for parent in self.iamc_aggregates():
-            if parent in per_parent_components:
+            if parent in split_parent_components:
                 continue
             iamc_dataframe.aggregate(variable=parent, append=True)
 
-        # Sum most variables across regions to "World", but aggregate per-capita (and other
-        # weighted) variables as a weighted mean so, e.g., World per-capita demand is
-        # World total demand / World population rather than the sum of regional per-capita values.
+    def _aggregate_iamc_regions(
+        self, iamc_dataframe: pyam.IamDataFrame, region_weights: dict[str, str]
+    ):
+        """Aggregate regional values to "World".
+
+        Most variables are summed across regions. Per-capita (and other weighted)
+        variables are aggregated as a weighted mean instead, so e.g. World per-capita
+        demand is World total demand / World population rather than the sum of the
+        regional per-capita values.
+        """
         plain_vars = [v for v in iamc_dataframe.variable if v not in region_weights]
         iamc_dataframe.aggregate_region(variable=plain_vars, region="World", append=True)
         for variable, weight in region_weights.items():
-            iamc_dataframe.aggregate_region(variable=variable, region="World", weight=weight, append=True)
+            iamc_dataframe.aggregate_region(
+                variable=variable, region="World", weight=weight, append=True
+            )
 
+    def _convert_iamc_units(self, iamc_dataframe: pyam.IamDataFrame):
+        """Convert the model's base units to the reporting units used in IAMC output."""
         iamc_dataframe.convert_unit(current="t/yr", to="Mt/yr", inplace=True)
         iamc_dataframe.convert_unit(current="t", to="Mt", inplace=True)
         iamc_dataframe.convert_unit(current="t/cap/yr", to="kg/cap/yr", factor=1000, inplace=True)
-
-        iamc_dataframe.to_excel(self.export_path("iamc", "output_iamc.xlsx"))
 
     def _build_iamc_df(
         self, mfa: CommonMFASystem, iamc_var: IamcVariable, constants: dict

--- a/remind_mfa/common/common_export.py
+++ b/remind_mfa/common/common_export.py
@@ -101,9 +101,11 @@ class CommonDataExporter(RemindMFABaseModel):
             ),
             IamcVariable(
                 variable_name="GDP|PPP",
-                calculation_function=lambda mfa: (mfa.parameters["gdppc"] * mfa.parameters["population"]/1e9).sum_to(("t", "r")),
+                calculation_function=lambda mfa: (
+                    mfa.parameters["gdppc"] * mfa.parameters["population"] / 1e9
+                ).sum_to(("t", "r")),
                 unit="billion USD_2005/yr",
-            )
+            ),
         ]
 
     def iamc_variables(self) -> list[IamcVariable]:
@@ -164,7 +166,9 @@ class CommonDataExporter(RemindMFABaseModel):
         plain_vars = [v for v in iamc_dataframe.variable if v not in region_weights]
         iamc_dataframe.aggregate_region(variable=plain_vars, region="World", append=True)
         for variable, weight in region_weights.items():
-            iamc_dataframe.aggregate_region(variable=variable, region="World", weight=weight, append=True)
+            iamc_dataframe.aggregate_region(
+                variable=variable, region="World", weight=weight, append=True
+            )
 
         iamc_dataframe.convert_unit(current="t/yr", to="Mt/yr", inplace=True)
         iamc_dataframe.convert_unit(current="t", to="Mt", inplace=True)
@@ -181,7 +185,7 @@ class CommonDataExporter(RemindMFABaseModel):
         if iamc_var.split_name is not None:
             df["variable"] += "|" + df[iamc_var.split_name]
             df = df.drop(columns=[iamc_var.split_name])
-            
+
         variables = list(dict.fromkeys(df["variable"]))
         return pyam.IamDataFrame(df, unit=iamc_var.unit, **constants), variables
 

--- a/remind_mfa/common/common_export.py
+++ b/remind_mfa/common/common_export.py
@@ -1,9 +1,11 @@
 import os
 from datetime import datetime
-from typing import Any, TYPE_CHECKING
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any, Callable, Optional, TYPE_CHECKING
 import flodym as fd
 import flodym.export as fde
 import pickle
+import pyam
 
 from remind_mfa.common.common_definition import RemindMFADefinition
 from remind_mfa.common.helpers import RemindMFABaseModel
@@ -15,6 +17,19 @@ if TYPE_CHECKING:
     from remind_mfa.common.common_model import CommonModel
     from remind_mfa.common.common_config import CommonCfg
     from remind_mfa.common.common_mfa_system import CommonMFASystem
+
+
+class IamcVariable(RemindMFABaseModel):
+    """Declarative specification of a single IAMC output variable."""
+
+    variable: str
+    """IAMC variable path, e.g. "Production|Iron and Steel|Steel"."""
+    getter: Callable[..., fd.FlodymArray]
+    """Given the future MFA system, returns the array to report, reduced to (t, r) or (t, r, <per-dim>)."""
+    unit: str
+    """Base unit of the array, e.g. "t/yr" or "t"."""
+    per: Optional[str] = None
+    """Display-column name to split into child variables (e.g. "Good"). None = single variable."""
 
 
 class CommonDataExporter(RemindMFABaseModel):
@@ -46,7 +61,7 @@ class CommonDataExporter(RemindMFABaseModel):
             self.assumptions_to_markdown()
             self.cfg_to_markdown(cfg=model.cfg)
         if self.cfg.iamc.do_export:
-            self.write_iamc(mfa=mfa)
+            self.write_iamc(model=model)
 
     def export_custom(self, model: "CommonModel"):
         pass
@@ -61,8 +76,61 @@ class CommonDataExporter(RemindMFABaseModel):
         with open(export_path, "wb") as f:
             pickle.dump(model, f)
 
-    def write_iamc(self, mfa: "CommonMFASystem"):
-        raise NotImplementedError("Subclasses must implement write_iamc method")
+    @property
+    def model_name(self) -> str:
+        """Model identifier for the IAMC "model" column, including the REMIND-MFA version."""
+        try:
+            return f"REMIND-MFA {version('remind-mfa')}"
+        except PackageNotFoundError:
+            return "REMIND-MFA"
+
+    def iamc_variables(self) -> list[IamcVariable]:
+        """Material-specific IAMC variable specifications. Override in subclasses."""
+        return []
+
+    def iamc_aggregates(self) -> list[str]:
+        """Extra parent variables to aggregate, beyond the automatic per-split parents.
+
+        Variables declared with a ``per`` dimension are summed back to their parent
+        automatically. Use this only for parents whose children are separate specs rather
+        than a ``per`` split (e.g. summing "…|Primary" and "…|Secondary" into their parent).
+        Override in subclasses.
+        """
+        return []
+
+    def write_iamc(self, model: "CommonModel"):
+        specs = self.iamc_variables()
+        if not specs:
+            return
+
+        mfa = model.future_mfa
+        constants = {"model": self.model_name, "scenario": model.cfg.model_switches.scenario}
+
+        idf = pyam.concat([self._build_idf(mfa, spec, constants) for spec in specs])
+
+        # A `per` variable is split into children on export, so sum it back to its parent.
+        # `iamc_aggregates` adds any further parents (e.g. summing sibling variables).
+        per_parents = [spec.variable for spec in specs if spec.per is not None]
+        for parent in dict.fromkeys(per_parents + self.iamc_aggregates()):
+            idf.aggregate(variable=parent, append=True)
+
+        idf.aggregate_region(variable=idf.variable, region="World", append=True)
+
+        idf.convert_unit(current="t/yr", to="Mt/yr", inplace=True)
+        idf.convert_unit(current="t", to="Mt", inplace=True)
+
+        idf.to_excel(self.export_path("iamc", "output_iamc.xlsx"))
+
+    def _build_idf(
+        self, mfa: "CommonMFASystem", spec: IamcVariable, constants: dict
+    ) -> pyam.IamDataFrame:
+        df = self.to_iamc_df(spec.getter(mfa))
+        if spec.per is not None:
+            df["variable"] = spec.variable + "|" + df[spec.per]
+            df = df.drop(columns=[spec.per])
+        else:
+            df["variable"] = spec.variable
+        return pyam.IamDataFrame(df, unit=spec.unit, **constants)
 
     def definition_to_markdown(self, definition: RemindMFADefinition):
 

--- a/remind_mfa/common/common_export.py
+++ b/remind_mfa/common/common_export.py
@@ -12,23 +12,23 @@ from remind_mfa.common.helpers import RemindMFABaseModel
 from remind_mfa.common.common_config import ExportCfg
 from remind_mfa.common.assumptions_doc import assumptions_str, assumptions_df
 from remind_mfa.common.common_mappings import CommonDisplayNames
+from remind_mfa.common.common_config import CommonCfg
+from remind_mfa.common.common_mfa_system import CommonMFASystem
 
 if TYPE_CHECKING:
     from remind_mfa.common.common_model import CommonModel
-    from remind_mfa.common.common_config import CommonCfg
-    from remind_mfa.common.common_mfa_system import CommonMFASystem
 
 
 class IamcVariable(RemindMFABaseModel):
     """Declarative specification of a single IAMC output variable."""
 
-    variable: str
+    variable_name: str
     """IAMC variable path, e.g. "Production|Iron and Steel|Steel"."""
-    getter: Callable[..., fd.FlodymArray]
+    calculation_function: Callable[[CommonMFASystem], fd.FlodymArray]
     """Given the future MFA system, returns the array to report, reduced to (t, r) or (t, r, <per-dim>)."""
     unit: str
     """Base unit of the array, e.g. "t/yr" or "t"."""
-    per: Optional[str] = None
+    split_name: Optional[str] = None
     """Display-column name to split into child variables (e.g. "Good"). None = single variable."""
     region_weight: Optional[str] = None
     """Variable to weight by when aggregating to "World" (e.g. "Population" for per-capita
@@ -95,10 +95,15 @@ class CommonDataExporter(RemindMFABaseModel):
         """
         return [
             IamcVariable(
-                variable="Population",
-                getter=lambda mfa: mfa.parameters["population"].sum_to(("t", "r")),
+                variable_name="Population",
+                calculation_function=lambda mfa: mfa.parameters["population"].sum_to(("t", "r")),
                 unit="cap",
             ),
+            IamcVariable(
+                variable_name="GDP|PPP",
+                calculation_function=lambda mfa: (mfa.parameters["gdppc"] * mfa.parameters["population"]/1e9).sum_to(("t", "r")),
+                unit="billion USD_2005/yr",
+            )
         ]
 
     def iamc_variables(self) -> list[IamcVariable]:
@@ -116,15 +121,15 @@ class CommonDataExporter(RemindMFABaseModel):
         return []
 
     def write_iamc(self, model: "CommonModel"):
-        specs = self.iamc_variables()
-        if not specs:
+        iamc_vars = self.iamc_variables()
+        if not iamc_vars:
             return
-        specs = self.common_iamc_variables() + specs
+        iamc_vars = self.common_iamc_variables() + iamc_vars
 
         mfa = model.future_mfa
         constants = {"model": self.model_name, "scenario": model.cfg.model_switches.scenario}
 
-        idfs = []
+        iamc_dataframes = []
         # Map each `per` parent to the exact child variables produced by its split, so the
         # parent is summed from those children only. Relying on pyam's default (all direct
         # children of the parent path) would wrongly pull in sibling variables that happen to
@@ -133,52 +138,52 @@ class CommonDataExporter(RemindMFABaseModel):
         # Variables aggregated to "World" as a weighted mean instead of a plain sum
         # (e.g. per-capita variables weighted by Population). Maps variable -> weight variable.
         region_weights: dict[str, str] = {}
-        for spec in specs:
-            idf, variables = self._build_idf(mfa, spec, constants)
-            idfs.append(idf)
-            if spec.per is not None:
-                per_parent_components.setdefault(spec.variable, []).extend(variables)
-            if spec.region_weight is not None:
-                region_weights.update({v: spec.region_weight for v in variables})
+        for iamc_var in iamc_vars:
+            iamc_df, variables = self._build_iamc_df(mfa, iamc_var, constants)
+            iamc_dataframes.append(iamc_df)
+            if iamc_var.split_name is not None:
+                per_parent_components.setdefault(iamc_var.variable_name, []).extend(variables)
+            if iamc_var.region_weight is not None:
+                region_weights.update({v: iamc_var.region_weight for v in variables})
 
-        idf = pyam.concat(idfs)
+        iamc_dataframe = pyam.concat(iamc_dataframes)
 
         # A `per` variable is split into children on export, so sum it back to its parent.
         for parent, components in per_parent_components.items():
-            idf.aggregate(variable=parent, components=components, append=True)
+            iamc_dataframe.aggregate(variable=parent, components=components, append=True)
         # `iamc_aggregates` adds any further parents whose children are separate specs
         # (e.g. summing sibling "…|Primary" and "…|Secondary" variables).
         for parent in self.iamc_aggregates():
             if parent in per_parent_components:
                 continue
-            idf.aggregate(variable=parent, append=True)
+            iamc_dataframe.aggregate(variable=parent, append=True)
 
         # Sum most variables across regions to "World", but aggregate per-capita (and other
-        # weighted) variables as a weight-weighted mean so, e.g., World per-capita demand is
+        # weighted) variables as a weighted mean so, e.g., World per-capita demand is
         # World total demand / World population rather than the sum of regional per-capita values.
-        plain_vars = [v for v in idf.variable if v not in region_weights]
-        idf.aggregate_region(variable=plain_vars, region="World", append=True)
+        plain_vars = [v for v in iamc_dataframe.variable if v not in region_weights]
+        iamc_dataframe.aggregate_region(variable=plain_vars, region="World", append=True)
         for variable, weight in region_weights.items():
-            idf.aggregate_region(variable=variable, region="World", weight=weight, append=True)
+            iamc_dataframe.aggregate_region(variable=variable, region="World", weight=weight, append=True)
 
-        idf.convert_unit(current="t/yr", to="Mt/yr", inplace=True)
-        idf.convert_unit(current="t", to="Mt", inplace=True)
-        idf.convert_unit(current="t/cap/yr", to="kg/cap/yr", factor=1000, inplace=True)
+        iamc_dataframe.convert_unit(current="t/yr", to="Mt/yr", inplace=True)
+        iamc_dataframe.convert_unit(current="t", to="Mt", inplace=True)
+        iamc_dataframe.convert_unit(current="t/cap/yr", to="kg/cap/yr", factor=1000, inplace=True)
 
-        idf.to_excel(self.export_path("iamc", "output_iamc.xlsx"))
+        iamc_dataframe.to_excel(self.export_path("iamc", "output_iamc.xlsx"))
 
-    def _build_idf(
-        self, mfa: "CommonMFASystem", spec: IamcVariable, constants: dict
+    def _build_iamc_df(
+        self, mfa: CommonMFASystem, iamc_var: IamcVariable, constants: dict
     ) -> tuple[pyam.IamDataFrame, list[str]]:
-        """Build the IamDataFrame for a spec and return it with the variable names it produced."""
-        df = self.to_iamc_df(spec.getter(mfa))
-        if spec.per is not None:
-            df["variable"] = spec.variable + "|" + df[spec.per]
-            df = df.drop(columns=[spec.per])
-        else:
-            df["variable"] = spec.variable
+        """Build the IamDataFrame for a iamc variable and return it with the variable names it produced."""
+        df = self.to_iamc_df(iamc_var.calculation_function(mfa))
+        df["variable"] = iamc_var.variable_name
+        if iamc_var.split_name is not None:
+            df["variable"] += "|" + df[iamc_var.split_name]
+            df = df.drop(columns=[iamc_var.split_name])
+            
         variables = list(dict.fromkeys(df["variable"]))
-        return pyam.IamDataFrame(df, unit=spec.unit, **constants), variables
+        return pyam.IamDataFrame(df, unit=iamc_var.unit, **constants), variables
 
     def definition_to_markdown(self, definition: RemindMFADefinition):
 

--- a/remind_mfa/common/common_export.py
+++ b/remind_mfa/common/common_export.py
@@ -110,7 +110,10 @@ class CommonDataExporter(RemindMFABaseModel):
         ]
 
     def iamc_variables(self) -> list[IamcVariable]:
-        """Material-specific IAMC variable specifications. Override in subclasses."""
+        """Material-specific IAMC variable specifications. Override in subclasses.
+        When adding IAMC variables, follow the nomenclature of the CIRCOMOD or the 
+        PRISMA project (templates can be found in the Cloud under data/iamc_nomenclature), 
+        if possible. Document the source (i.e. which template you took each variable from)."""
         return []
 
     def iamc_aggregates(self) -> list[str]:

--- a/remind_mfa/common/common_export.py
+++ b/remind_mfa/common/common_export.py
@@ -111,8 +111,8 @@ class CommonDataExporter(RemindMFABaseModel):
 
     def iamc_variables(self) -> list[IamcVariable]:
         """Material-specific IAMC variable specifications. Override in subclasses.
-        When adding IAMC variables, follow the nomenclature of the CIRCOMOD or the 
-        PRISMA project (templates can be found in the Cloud under data/iamc_nomenclature), 
+        When adding IAMC variables, follow the nomenclature of the CIRCOMOD or the
+        PRISMA project (templates can be found in the Cloud under data/iamc_nomenclature),
         if possible. Document the source (i.e. which template you took each variable from)."""
         return []
 

--- a/remind_mfa/plastics/plastics_export.py
+++ b/remind_mfa/plastics/plastics_export.py
@@ -47,7 +47,7 @@ class PlasticsDataExporter(CommonDataExporter):
         return [
             # production
             IamcVariable(
-                variable_name="Production|Chemicals|Plastics|Primary", # PRISMA nomenclature
+                variable_name="Production|Chemicals|Plastics|Primary",  # PRISMA nomenclature
                 calculation_function=lambda mfa: (
                     mfa.flows["polymerization => primary_market"].sum_to(("t", "r"))
                     - mfa.flows["reclchem => HVC_input"]
@@ -55,7 +55,7 @@ class PlasticsDataExporter(CommonDataExporter):
                 unit="t/yr",
             ),
             IamcVariable(
-                variable_name="Production|Chemicals|Plastics|Secondary", # PRISMA nomenclature
+                variable_name="Production|Chemicals|Plastics|Secondary",  # PRISMA nomenclature
                 calculation_function=lambda mfa: (
                     mfa.flows["reclmech => primary_market"] + mfa.flows["reclchem => HVC_input"]
                 ).sum_to(("t", "r")),
@@ -63,7 +63,7 @@ class PlasticsDataExporter(CommonDataExporter):
             ),
             # demand by good
             IamcVariable(
-                variable_name="Material Demand|Chemicals|Plastics", # PRISMA nomenclature
+                variable_name="Material Demand|Chemicals|Plastics",  # PRISMA nomenclature
                 calculation_function=lambda mfa: mfa.stocks["in_use"].inflow.sum_to(
                     ("t", "r", "g")
                 ),
@@ -81,21 +81,21 @@ class PlasticsDataExporter(CommonDataExporter):
             ),
             # trade
             IamcVariable(
-                variable_name="Import|Industry|Chemicals|Plastics|Primary Forms", # CIRCOMOD nomenclature (further differentiated by stage)
+                variable_name="Import|Industry|Chemicals|Plastics|Primary Forms",  # CIRCOMOD nomenclature (further differentiated by stage)
                 calculation_function=lambda mfa: mfa.flows["imports => primary_market"].sum_to(
                     ("t", "r")
                 ),
                 unit="t/yr",
             ),
             IamcVariable(
-                variable_name="Export|Industry|Chemicals|Plastics|Primary Forms", # CIRCOMOD nomenclature (further differentiated by stage)
+                variable_name="Export|Industry|Chemicals|Plastics|Primary Forms",  # CIRCOMOD nomenclature (further differentiated by stage)
                 calculation_function=lambda mfa: mfa.flows["primary_market => exports"].sum_to(
                     ("t", "r")
                 ),
                 unit="t/yr",
             ),
             IamcVariable(
-                variable_name="Import|Industry|Chemicals|Plastics|Goods", # CIRCOMOD nomenclature (further differentiated by stage)
+                variable_name="Import|Industry|Chemicals|Plastics|Goods",  # CIRCOMOD nomenclature (further differentiated by stage)
                 calculation_function=lambda mfa: mfa.flows["imports => good_market"].sum_to(
                     ("t", "r", "g")
                 ),
@@ -103,7 +103,7 @@ class PlasticsDataExporter(CommonDataExporter):
                 split_name="Good",
             ),
             IamcVariable(
-                variable_name="Export|Industry|Chemicals|Plastics|Goods", # CIRCOMOD nomenclature (further differentiated by stage)
+                variable_name="Export|Industry|Chemicals|Plastics|Goods",  # CIRCOMOD nomenclature (further differentiated by stage)
                 calculation_function=lambda mfa: mfa.flows["good_market => exports"].sum_to(
                     ("t", "r", "g")
                 ),

--- a/remind_mfa/plastics/plastics_export.py
+++ b/remind_mfa/plastics/plastics_export.py
@@ -47,31 +47,31 @@ class PlasticsDataExporter(CommonDataExporter):
         return [
             # production
             IamcVariable(
-                variable="Production|Chemicals|Plastics|Primary",
-                getter=lambda mfa: (
+                variable_name="Production|Chemicals|Plastics|Primary",
+                calculation_function=lambda mfa: (
                     mfa.flows["polymerization => primary_market"].sum_to(("t", "r"))
                     - mfa.flows["reclchem => HVC_input"]
                 ),
                 unit="t/yr",
             ),
             IamcVariable(
-                variable="Production|Chemicals|Plastics|Secondary",
-                getter=lambda mfa: (
+                variable_name="Production|Chemicals|Plastics|Secondary",
+                calculation_function=lambda mfa: (
                     mfa.flows["reclmech => primary_market"] + mfa.flows["reclchem => HVC_input"]
                 ).sum_to(("t", "r")),
                 unit="t/yr",
             ),
             # demand by good
             IamcVariable(
-                variable="Material Demand|Chemicals|Plastics",
-                getter=lambda mfa: mfa.stocks["in_use"].inflow.sum_to(("t", "r", "g")),
+                variable_name="Material Demand|Chemicals|Plastics",
+                calculation_function=lambda mfa: mfa.stocks["in_use"].inflow.sum_to(("t", "r", "g")),
                 unit="t/yr",
-                per="Good",
+                split_name="Good",
             ),
             # demand per capita
             IamcVariable(
-                variable="Material Demand|Chemicals|Plastics|Per Capita",
-                getter=lambda mfa: (
+                variable_name="Material Demand|Chemicals|Plastics|Per Capita",
+                calculation_function=lambda mfa: (
                     mfa.stocks["in_use"].inflow / mfa.parameters["population"]
                 ).sum_to(("t", "r")),
                 unit="t/cap/yr",
@@ -79,26 +79,26 @@ class PlasticsDataExporter(CommonDataExporter):
             ),
             # trade
             IamcVariable(
-                variable="Import|Industry|Chemicals|Plastics|Primary Forms",
-                getter=lambda mfa: mfa.flows["imports => primary_market"].sum_to(("t", "r")),
+                variable_name="Import|Industry|Chemicals|Plastics|Primary Forms",
+                calculation_function=lambda mfa: mfa.flows["imports => primary_market"].sum_to(("t", "r")),
                 unit="t/yr",
             ),
             IamcVariable(
-                variable="Export|Industry|Chemicals|Plastics|Primary Forms",
-                getter=lambda mfa: mfa.flows["primary_market => exports"].sum_to(("t", "r")),
+                variable_name="Export|Industry|Chemicals|Plastics|Primary Forms",
+                calculation_function=lambda mfa: mfa.flows["primary_market => exports"].sum_to(("t", "r")),
                 unit="t/yr",
             ),
             IamcVariable(
-                variable="Import|Industry|Chemicals|Plastics|Goods",
-                getter=lambda mfa: mfa.flows["imports => good_market"].sum_to(("t", "r", "g")),
+                variable_name="Import|Industry|Chemicals|Plastics|Goods",
+                calculation_function=lambda mfa: mfa.flows["imports => good_market"].sum_to(("t", "r", "g")),
                 unit="t/yr",
-                per="Good",
+                split_name="Good",
             ),
             IamcVariable(
-                variable="Export|Industry|Chemicals|Plastics|Goods",
-                getter=lambda mfa: mfa.flows["good_market => exports"].sum_to(("t", "r", "g")),
+                variable_name="Export|Industry|Chemicals|Plastics|Goods",
+                calculation_function=lambda mfa: mfa.flows["good_market => exports"].sum_to(("t", "r", "g")),
                 unit="t/yr",
-                per="Good",
+                split_name="Good",
             ),
         ]
 

--- a/remind_mfa/plastics/plastics_export.py
+++ b/remind_mfa/plastics/plastics_export.py
@@ -47,7 +47,7 @@ class PlasticsDataExporter(CommonDataExporter):
         return [
             # production
             IamcVariable(
-                variable_name="Production|Chemicals|Plastics|Primary",
+                variable_name="Production|Chemicals|Plastics|Primary", # PRISMA nomenclature
                 calculation_function=lambda mfa: (
                     mfa.flows["polymerization => primary_market"].sum_to(("t", "r"))
                     - mfa.flows["reclchem => HVC_input"]
@@ -55,7 +55,7 @@ class PlasticsDataExporter(CommonDataExporter):
                 unit="t/yr",
             ),
             IamcVariable(
-                variable_name="Production|Chemicals|Plastics|Secondary",
+                variable_name="Production|Chemicals|Plastics|Secondary", # PRISMA nomenclature
                 calculation_function=lambda mfa: (
                     mfa.flows["reclmech => primary_market"] + mfa.flows["reclchem => HVC_input"]
                 ).sum_to(("t", "r")),
@@ -63,7 +63,7 @@ class PlasticsDataExporter(CommonDataExporter):
             ),
             # demand by good
             IamcVariable(
-                variable_name="Material Demand|Chemicals|Plastics",
+                variable_name="Material Demand|Chemicals|Plastics", # PRISMA nomenclature
                 calculation_function=lambda mfa: mfa.stocks["in_use"].inflow.sum_to(
                     ("t", "r", "g")
                 ),
@@ -81,21 +81,21 @@ class PlasticsDataExporter(CommonDataExporter):
             ),
             # trade
             IamcVariable(
-                variable_name="Import|Industry|Chemicals|Plastics|Primary Forms",
+                variable_name="Import|Industry|Chemicals|Plastics|Primary Forms", # CIRCOMOD nomenclature (further differentiated by stage)
                 calculation_function=lambda mfa: mfa.flows["imports => primary_market"].sum_to(
                     ("t", "r")
                 ),
                 unit="t/yr",
             ),
             IamcVariable(
-                variable_name="Export|Industry|Chemicals|Plastics|Primary Forms",
+                variable_name="Export|Industry|Chemicals|Plastics|Primary Forms", # CIRCOMOD nomenclature (further differentiated by stage)
                 calculation_function=lambda mfa: mfa.flows["primary_market => exports"].sum_to(
                     ("t", "r")
                 ),
                 unit="t/yr",
             ),
             IamcVariable(
-                variable_name="Import|Industry|Chemicals|Plastics|Goods",
+                variable_name="Import|Industry|Chemicals|Plastics|Goods", # CIRCOMOD nomenclature (further differentiated by stage)
                 calculation_function=lambda mfa: mfa.flows["imports => good_market"].sum_to(
                     ("t", "r", "g")
                 ),
@@ -103,7 +103,7 @@ class PlasticsDataExporter(CommonDataExporter):
                 split_name="Good",
             ),
             IamcVariable(
-                variable_name="Export|Industry|Chemicals|Plastics|Goods",
+                variable_name="Export|Industry|Chemicals|Plastics|Goods", # CIRCOMOD nomenclature (further differentiated by stage)
                 calculation_function=lambda mfa: mfa.flows["good_market => exports"].sum_to(
                     ("t", "r", "g")
                 ),

--- a/remind_mfa/plastics/plastics_export.py
+++ b/remind_mfa/plastics/plastics_export.py
@@ -16,7 +16,6 @@ class PlasticsDataExporter(CommonDataExporter):
             self.export_use_data_by_region_and_year(mfa=model.future_mfa)
             self.export_recycling_data_by_region_and_year(mfa=model.future_mfa)
             self.export_stock_extrapolation(model=model)
-            self.export_stock(mfa=model.historic_mfa)
 
     def export_stock_extrapolation(self, model: "PlasticsModel"):
         model.stock_handler.pure_parameters.to_df().to_csv(
@@ -25,15 +24,6 @@ class PlasticsDataExporter(CommonDataExporter):
         model.stock_handler.bound_list.bound_list[0].upper_bound.to_df().to_csv(
             self.export_path("csv", "stock_extrapolation_saturationLevel.csv")
         )
-
-    def export_stock(self, mfa: fd.MFASystem):
-        inflow = mfa.stocks["in_use_historic"].inflow.sum_to(("g", "h")).to_df()
-        inflow["variable"] = "inflow"
-        outflow = mfa.stocks["in_use_historic"].outflow.sum_to(("g", "h")).to_df()
-        outflow["variable"] = "outflow"
-        stock = mfa.stocks["in_use_historic"].stock.sum_to(("g", "h")).to_df()
-        stock["variable"] = "stock"
-        pd.concat([inflow, outflow, stock]).to_csv(self.export_path("csv", "stock.csv"))
 
     def export_eol_data_by_region_and_year(self, mfa: fd.MFASystem):
         eol_data = (

--- a/remind_mfa/plastics/plastics_export.py
+++ b/remind_mfa/plastics/plastics_export.py
@@ -1,9 +1,8 @@
 import flodym as fd
 import pandas as pd
-import pyam
 from typing import TYPE_CHECKING
 
-from remind_mfa.common.common_export import CommonDataExporter
+from remind_mfa.common.common_export import CommonDataExporter, IamcVariable
 
 if TYPE_CHECKING:
     from remind_mfa.plastics.plastics_model import PlasticsModel
@@ -54,116 +53,35 @@ class PlasticsDataExporter(CommonDataExporter):
         df = recl_data.sum_to(("t", "r", "m")).to_df(index=True)
         df.to_csv(self.export_path("csv", "recycling_by_region_year.csv"), index=True)
 
-    def write_iamc(self, mfa: fd.MFASystem):
+    def iamc_variables(self) -> list[IamcVariable]:
+        return [
+            # production
+            IamcVariable(
+                variable="Production|Chemicals|Plastics|Primary",
+                getter=lambda mfa: (
+                    mfa.flows["polymerization => primary_market"]
+                    - mfa.flows["reclchem => HVC_input"]
+                ),
+                unit="t/yr",
+            ),
+            IamcVariable(
+                variable="Production|Chemicals|Plastics|Secondary",
+                getter=lambda mfa: (
+                    mfa.flows["reclmech => primary_market"] + mfa.flows["reclchem => HVC_input"]
+                ),
+                unit="t/yr",
+            ),
+            # demand by good
+            IamcVariable(
+                variable="Material Demand|Chemicals|Plastics",
+                getter=lambda mfa: mfa.stocks["in_use"].inflow.sum_to(("t", "r", "g")),
+                unit="t/yr",
+                per="Good",
+            ),
+        ]
 
-        model = "REMIND 3.0"
-        scenario = "SSP2_NPi"
-        constants = {"model": model, "scenario": scenario}
-
-        # production
-        ## primary production
-        prod_virgin = (
-            mfa.flows["polymerization => primary_market"] - mfa.flows["reclchem => HVC_input"]
-        )
-        prod_virgin_df = self.to_iamc_df(prod_virgin.sum_to(("t", "r")))
-        prod_virgin_idf = pyam.IamDataFrame(
-            prod_virgin_df,
-            variable="Production|Chemicals|Plastics|Primary",
-            unit="Mt/yr",
-            **constants,
-        )
-        ## secondary production
-        prod_recl = mfa.flows["reclmech => primary_market"] + mfa.flows["reclchem => HVC_input"]
-        prod_recl_df = self.to_iamc_df(prod_recl.sum_to(("t", "r")))
-        prod_recl_idf = pyam.IamDataFrame(
-            prod_recl_df,
-            variable="Production|Chemicals|Plastics|Secondary",
-            unit="Mt/yr",
-            **constants,
-        )
-        ## total production
-        prod_idf = pyam.concat(
-            [
-                prod_virgin_idf,
-                prod_recl_idf,
-            ]
-        )
-        prod_idf.aggregate(
-            variable="Production|Chemicals|Plastics",
-            append=True,
-        )
-
-        # demand
-        ## demand by good
-        plastic_demand_by_good = mfa.stocks["in_use"].inflow.sum_to(("t", "r", "g"))
-        demand_df = self.to_iamc_df(plastic_demand_by_good)
-        demand_df["variable"] = "Material Demand|Chemicals|Plastics|" + demand_df["Good"]
-        demand_df = demand_df.drop(columns=["Good"])
-        demand_idf = pyam.IamDataFrame(
-            demand_df,
-            unit="Mt/yr",
-            **constants,
-        )
-        demand_idf.aggregate(
-            variable="Material Demand|Chemicals|Plastics",
-            append=True,
-        )
-        ## demand by origin (primary/secondary) and good
-        recycled = prod_recl / (prod_virgin + prod_recl)
-        ### primary
-        plastic_demand_virgin = mfa.stocks["in_use"].inflow * (1 - recycled)
-        demand_virgin_df = self.to_iamc_df(plastic_demand_virgin.sum_to(("t", "r", "g")))
-        demand_virgin_df["variable"] = (
-            "Material Demand|Chemicals|Plastics|Primary|" + demand_virgin_df["Good"]
-        )
-        demand_virgin_df = demand_virgin_df.drop(columns=["Good"])
-        demand_virgin_idf = pyam.IamDataFrame(
-            demand_virgin_df,
-            unit="Mt/yr",
-            **constants,
-        )
-        demand_virgin_idf.aggregate(
-            variable="Material Demand|Chemicals|Plastics|Primary",
-            append=True,
-        )
-        ### secondary
-        plastic_demand_recl = mfa.stocks["in_use"].inflow * recycled
-        demand_recl_df = self.to_iamc_df(plastic_demand_recl.sum_to(("t", "r", "g")))
-        demand_recl_df["variable"] = (
-            "Material Demand|Chemicals|Plastics|Secondary|" + demand_recl_df["Good"]
-        )
-        demand_recl_df = demand_recl_df.drop(columns=["Good"])
-        demand_recl_idf = pyam.IamDataFrame(
-            demand_recl_df,
-            unit="Mt/yr",
-            **constants,
-        )
-        demand_recl_idf.aggregate(
-            variable="Material Demand|Chemicals|Plastics|Secondary",
-            append=True,
-        )
-        demand_origin_idf = pyam.concat(
-            [
-                demand_virgin_idf,
-                demand_recl_idf,
-            ]
-        )
-        # demand_origin_idf.aggregate(
-        #     variable="Material Demand|Chemicals|Plastics",
-        #     append=True,
-        # )
-
-        idf = pyam.concat(
-            [
-                prod_idf,
-                demand_idf,
-                demand_origin_idf,
-            ]
-        )
-        idf.aggregate_region(
-            variable=idf.variable,
-            region="World",
-            append=True,
-        )
-
-        idf.to_excel(self.export_path("iamc", f"output_iamc.xlsx"))
+    def iamc_aggregates(self) -> list[str]:
+        # Primary + Secondary are separate specs (no `per`), so their parent must be
+        # aggregated explicitly. "Material Demand|Chemicals|Plastics" is handled
+        # automatically via its `per="Good"` split.
+        return ["Production|Chemicals|Plastics"]

--- a/remind_mfa/plastics/plastics_export.py
+++ b/remind_mfa/plastics/plastics_export.py
@@ -59,7 +59,7 @@ class PlasticsDataExporter(CommonDataExporter):
             IamcVariable(
                 variable="Production|Chemicals|Plastics|Primary",
                 getter=lambda mfa: (
-                    mfa.flows["polymerization => primary_market"]
+                    mfa.flows["polymerization => primary_market"].sum_to(("t", "r"))
                     - mfa.flows["reclchem => HVC_input"]
                 ),
                 unit="t/yr",
@@ -68,13 +68,46 @@ class PlasticsDataExporter(CommonDataExporter):
                 variable="Production|Chemicals|Plastics|Secondary",
                 getter=lambda mfa: (
                     mfa.flows["reclmech => primary_market"] + mfa.flows["reclchem => HVC_input"]
-                ),
+                ).sum_to(("t", "r")),
                 unit="t/yr",
             ),
             # demand by good
             IamcVariable(
                 variable="Material Demand|Chemicals|Plastics",
                 getter=lambda mfa: mfa.stocks["in_use"].inflow.sum_to(("t", "r", "g")),
+                unit="t/yr",
+                per="Good",
+            ),
+            # demand per capita
+            IamcVariable(
+                variable="Material Demand|Chemicals|Plastics|Per Capita",
+                getter=lambda mfa: (
+                    mfa.stocks["in_use"].inflow
+                    / mfa.parameters["population"]
+                ).sum_to(("t", "r")),
+                unit="t/cap/yr",
+                region_weight="Population",
+            ),
+            # trade
+            IamcVariable(
+                variable="Import|Industry|Chemicals|Plastics|Primary Forms",
+                getter=lambda mfa: mfa.flows["imports => primary_market"].sum_to(("t", "r")),
+                unit="t/yr",
+            ),
+            IamcVariable(
+                variable="Export|Industry|Chemicals|Plastics|Primary Forms",
+                getter=lambda mfa: mfa.flows["primary_market => exports"].sum_to(("t", "r")),
+                unit="t/yr",
+            ),
+            IamcVariable(
+                variable="Import|Industry|Chemicals|Plastics|Goods",
+                getter=lambda mfa: mfa.flows["imports => good_market"].sum_to(("t", "r", "g")),
+                unit="t/yr",
+                per="Good",
+            ),
+            IamcVariable(
+                variable="Export|Industry|Chemicals|Plastics|Goods",
+                getter=lambda mfa: mfa.flows["good_market => exports"].sum_to(("t", "r", "g")),
                 unit="t/yr",
                 per="Good",
             ),

--- a/remind_mfa/plastics/plastics_export.py
+++ b/remind_mfa/plastics/plastics_export.py
@@ -72,8 +72,7 @@ class PlasticsDataExporter(CommonDataExporter):
             IamcVariable(
                 variable="Material Demand|Chemicals|Plastics|Per Capita",
                 getter=lambda mfa: (
-                    mfa.stocks["in_use"].inflow
-                    / mfa.parameters["population"]
+                    mfa.stocks["in_use"].inflow / mfa.parameters["population"]
                 ).sum_to(("t", "r")),
                 unit="t/cap/yr",
                 region_weight="Population",

--- a/remind_mfa/plastics/plastics_export.py
+++ b/remind_mfa/plastics/plastics_export.py
@@ -64,7 +64,9 @@ class PlasticsDataExporter(CommonDataExporter):
             # demand by good
             IamcVariable(
                 variable_name="Material Demand|Chemicals|Plastics",
-                calculation_function=lambda mfa: mfa.stocks["in_use"].inflow.sum_to(("t", "r", "g")),
+                calculation_function=lambda mfa: mfa.stocks["in_use"].inflow.sum_to(
+                    ("t", "r", "g")
+                ),
                 unit="t/yr",
                 split_name="Good",
             ),
@@ -80,23 +82,31 @@ class PlasticsDataExporter(CommonDataExporter):
             # trade
             IamcVariable(
                 variable_name="Import|Industry|Chemicals|Plastics|Primary Forms",
-                calculation_function=lambda mfa: mfa.flows["imports => primary_market"].sum_to(("t", "r")),
+                calculation_function=lambda mfa: mfa.flows["imports => primary_market"].sum_to(
+                    ("t", "r")
+                ),
                 unit="t/yr",
             ),
             IamcVariable(
                 variable_name="Export|Industry|Chemicals|Plastics|Primary Forms",
-                calculation_function=lambda mfa: mfa.flows["primary_market => exports"].sum_to(("t", "r")),
+                calculation_function=lambda mfa: mfa.flows["primary_market => exports"].sum_to(
+                    ("t", "r")
+                ),
                 unit="t/yr",
             ),
             IamcVariable(
                 variable_name="Import|Industry|Chemicals|Plastics|Goods",
-                calculation_function=lambda mfa: mfa.flows["imports => good_market"].sum_to(("t", "r", "g")),
+                calculation_function=lambda mfa: mfa.flows["imports => good_market"].sum_to(
+                    ("t", "r", "g")
+                ),
                 unit="t/yr",
                 split_name="Good",
             ),
             IamcVariable(
                 variable_name="Export|Industry|Chemicals|Plastics|Goods",
-                calculation_function=lambda mfa: mfa.flows["good_market => exports"].sum_to(("t", "r", "g")),
+                calculation_function=lambda mfa: mfa.flows["good_market => exports"].sum_to(
+                    ("t", "r", "g")
+                ),
                 unit="t/yr",
                 split_name="Good",
             ),

--- a/remind_mfa/steel/steel_export.py
+++ b/remind_mfa/steel/steel_export.py
@@ -6,28 +6,28 @@ class SteelDataExporter(CommonDataExporter):
     def iamc_variables(self) -> list[IamcVariable]:
         return [
             IamcVariable(
-                variable="Production|Iron and Steel|Steel",
-                getter=lambda mfa: mfa.flows["forming => ip_market"].sum_to(("t", "r")),
+                variable_name="Production|Iron and Steel|Steel",
+                calculation_function=lambda mfa: mfa.flows["forming => ip_market"].sum_to(("t", "r")),
                 unit="t/yr",
             ),
             IamcVariable(
-                variable="Material Demand|Iron and Steel|Steel",
-                getter=lambda mfa: (
+                variable_name="Material Demand|Iron and Steel|Steel",
+                calculation_function=lambda mfa: (
                     mfa.flows["fabrication => good_market"] / mfa.parameters["fabrication_yield"]
                 ).sum_to(("t", "r", "g")),
                 unit="t/yr",
-                per="Good",
+                split_name="Good",
             ),
             IamcVariable(
-                variable="Material Stock|Iron and Steel|Steel",
-                getter=lambda mfa: mfa.stocks["in_use"].stock.sum_to(("t", "r", "g")),
+                variable_name="Material Stock|Iron and Steel|Steel",
+                calculation_function=lambda mfa: mfa.stocks["in_use"].stock.sum_to(("t", "r", "g")),
                 unit="t",
-                per="Good",
+                split_name="Good",
             ),
             IamcVariable(
-                variable="Scrap|Iron and Steel|Steel",
-                getter=lambda mfa: mfa.stocks["in_use"].outflow.sum_to(("t", "r", "g")),
+                variable_name="Scrap|Iron and Steel|Steel",
+                calculation_function=lambda mfa: mfa.stocks["in_use"].outflow.sum_to(("t", "r", "g")),
                 unit="t/yr",
-                per="Good",
+                split_name="Good",
             ),
         ]

--- a/remind_mfa/steel/steel_export.py
+++ b/remind_mfa/steel/steel_export.py
@@ -6,14 +6,14 @@ class SteelDataExporter(CommonDataExporter):
     def iamc_variables(self) -> list[IamcVariable]:
         return [
             IamcVariable(
-                variable_name="Production|Iron and Steel|Steel",
+                variable_name="Production|Iron and Steel|Steel", # PRISMA nomenclature
                 calculation_function=lambda mfa: mfa.flows["forming => ip_market"].sum_to(
                     ("t", "r")
                 ),
                 unit="t/yr",
             ),
             IamcVariable(
-                variable_name="Material Demand|Iron and Steel|Steel",
+                variable_name="Material Demand|Iron and Steel|Steel", # PRISMA nomenclature
                 calculation_function=lambda mfa: (
                     mfa.flows["fabrication => good_market"] / mfa.parameters["fabrication_yield"]
                 ).sum_to(("t", "r", "g")),
@@ -21,13 +21,13 @@ class SteelDataExporter(CommonDataExporter):
                 split_name="Good",
             ),
             IamcVariable(
-                variable_name="Material Stock|Iron and Steel|Steel",
+                variable_name="Material Stock|Iron and Steel|Steel", # PRISMA nomenclature
                 calculation_function=lambda mfa: mfa.stocks["in_use"].stock.sum_to(("t", "r", "g")),
                 unit="t",
                 split_name="Good",
             ),
             IamcVariable(
-                variable_name="Scrap|Iron and Steel|Steel",
+                variable_name="Scrap|Iron and Steel|Steel", # PRISMA nomenclature
                 calculation_function=lambda mfa: mfa.stocks["in_use"].outflow.sum_to(
                     ("t", "r", "g")
                 ),

--- a/remind_mfa/steel/steel_export.py
+++ b/remind_mfa/steel/steel_export.py
@@ -7,7 +7,9 @@ class SteelDataExporter(CommonDataExporter):
         return [
             IamcVariable(
                 variable_name="Production|Iron and Steel|Steel",
-                calculation_function=lambda mfa: mfa.flows["forming => ip_market"].sum_to(("t", "r")),
+                calculation_function=lambda mfa: mfa.flows["forming => ip_market"].sum_to(
+                    ("t", "r")
+                ),
                 unit="t/yr",
             ),
             IamcVariable(
@@ -26,7 +28,9 @@ class SteelDataExporter(CommonDataExporter):
             ),
             IamcVariable(
                 variable_name="Scrap|Iron and Steel|Steel",
-                calculation_function=lambda mfa: mfa.stocks["in_use"].outflow.sum_to(("t", "r", "g")),
+                calculation_function=lambda mfa: mfa.stocks["in_use"].outflow.sum_to(
+                    ("t", "r", "g")
+                ),
                 unit="t/yr",
                 split_name="Good",
             ),

--- a/remind_mfa/steel/steel_export.py
+++ b/remind_mfa/steel/steel_export.py
@@ -6,14 +6,14 @@ class SteelDataExporter(CommonDataExporter):
     def iamc_variables(self) -> list[IamcVariable]:
         return [
             IamcVariable(
-                variable_name="Production|Iron and Steel|Steel", # PRISMA nomenclature
+                variable_name="Production|Iron and Steel|Steel",  # PRISMA nomenclature
                 calculation_function=lambda mfa: mfa.flows["forming => ip_market"].sum_to(
                     ("t", "r")
                 ),
                 unit="t/yr",
             ),
             IamcVariable(
-                variable_name="Material Demand|Iron and Steel|Steel", # PRISMA nomenclature
+                variable_name="Material Demand|Iron and Steel|Steel",  # PRISMA nomenclature
                 calculation_function=lambda mfa: (
                     mfa.flows["fabrication => good_market"] / mfa.parameters["fabrication_yield"]
                 ).sum_to(("t", "r", "g")),
@@ -21,13 +21,13 @@ class SteelDataExporter(CommonDataExporter):
                 split_name="Good",
             ),
             IamcVariable(
-                variable_name="Material Stock|Iron and Steel|Steel", # PRISMA nomenclature
+                variable_name="Material Stock|Iron and Steel|Steel",  # PRISMA nomenclature
                 calculation_function=lambda mfa: mfa.stocks["in_use"].stock.sum_to(("t", "r", "g")),
                 unit="t",
                 split_name="Good",
             ),
             IamcVariable(
-                variable_name="Scrap|Iron and Steel|Steel", # PRISMA nomenclature
+                variable_name="Scrap|Iron and Steel|Steel",  # PRISMA nomenclature
                 calculation_function=lambda mfa: mfa.stocks["in_use"].outflow.sum_to(
                     ("t", "r", "g")
                 ),

--- a/remind_mfa/steel/steel_export.py
+++ b/remind_mfa/steel/steel_export.py
@@ -1,85 +1,33 @@
-import pyam
-import flodym as fd
-
-from remind_mfa.common.common_export import CommonDataExporter
+from remind_mfa.common.common_export import CommonDataExporter, IamcVariable
 
 
 class SteelDataExporter(CommonDataExporter):
 
-    def write_iamc(self, mfa: fd.MFASystem):
-
-        model = "REMIND 3.0"
-        scenario = "SSP2_NPi"
-        constants = {"model": model, "scenario": scenario}
-
-        # production
-        prod_df = self.to_iamc_df(mfa.flows["forming => ip_market"])
-        prod_idf = pyam.IamDataFrame(
-            prod_df,
-            variable="Production|Iron and Steel|Steel",
-            unit="t/yr",
-            **constants,
-        )
-
-        # demand
-        steel_demand_by_good = (
-            mfa.flows["fabrication => good_market"] / mfa.parameters["fabrication_yield"]
-        )
-        demand_df = self.to_iamc_df(steel_demand_by_good)
-        demand_df["variable"] = "Material Demand|Iron and Steel|Steel|" + demand_df["Good"]
-        demand_df = demand_df.drop(columns=["Good"])
-        demand_idf = pyam.IamDataFrame(
-            demand_df,
-            unit="t/yr",
-            **constants,
-        )
-        demand_idf.aggregate(
-            variable="Material Demand|Iron and Steel|Steel",
-            append=True,
-        )
-
-        # stocks
-        stock_df = self.to_iamc_df(mfa.stocks["in_use"].stock)
-        stock_df["variable"] = "Material Stock|Iron and Steel|Steel|" + stock_df["Good"]
-        stock_df = stock_df.drop(columns=["Good"])
-        stock_idf = pyam.IamDataFrame(
-            stock_df,
-            unit="t",
-            **constants,
-        )
-        stock_idf.aggregate(
-            variable="Material Stock|Iron and Steel|Steel",
-            append=True,
-        )
-
-        # scrap
-        scrap_df = self.to_iamc_df(mfa.stocks["in_use"].outflow)
-        scrap_df["variable"] = "Scrap|Iron and Steel|Steel|" + scrap_df["Good"]
-        scrap_df = scrap_df.drop(columns=["Good"])
-        scrap_idf = pyam.IamDataFrame(
-            scrap_df,
-            unit="t/yr",
-            **constants,
-        )
-        scrap_idf.aggregate(
-            variable="Scrap|Iron and Steel|Steel",
-            append=True,
-        )
-
-        idf = pyam.concat(
-            [
-                prod_idf,
-                demand_idf,
-                stock_idf,
-                scrap_idf,
-            ]
-        )
-        idf.aggregate_region(
-            variable=idf.variable,
-            region="World",
-            append=True,
-        )
-        idf.convert_unit(current="t/yr", to="Mt/yr", inplace=True)
-        idf.convert_unit(current="t", to="Mt", inplace=True)
-
-        idf.to_excel(self.export_path("iamc", f"output_iamc.xlsx"))
+    def iamc_variables(self) -> list[IamcVariable]:
+        return [
+            IamcVariable(
+                variable="Production|Iron and Steel|Steel",
+                getter=lambda mfa: mfa.flows["forming => ip_market"].sum_to(("t", "r")),
+                unit="t/yr",
+            ),
+            IamcVariable(
+                variable="Material Demand|Iron and Steel|Steel",
+                getter=lambda mfa: (
+                    mfa.flows["fabrication => good_market"] / mfa.parameters["fabrication_yield"]
+                ).sum_to(("t", "r", "g")),
+                unit="t/yr",
+                per="Good",
+            ),
+            IamcVariable(
+                variable="Material Stock|Iron and Steel|Steel",
+                getter=lambda mfa: mfa.stocks["in_use"].stock.sum_to(("t", "r", "g")),
+                unit="t",
+                per="Good",
+            ),
+            IamcVariable(
+                variable="Scrap|Iron and Steel|Steel",
+                getter=lambda mfa: mfa.stocks["in_use"].outflow.sum_to(("t", "r", "g")),
+                unit="t/yr",
+                per="Good",
+            ),
+        ]

--- a/scripts/plot_iamc_vs_validation.py
+++ b/scripts/plot_iamc_vs_validation.py
@@ -1,0 +1,240 @@
+"""Plot a material model's IAMC outputs against the curated validation data.
+
+For every variable that appears in both the model IAMC output and the validation ``.mif`` file,
+one PNG is produced: region panels (subplots), one colour per model, one linestyle per scenario.
+
+Usage::
+
+    uv run python scripts/plot_iamc_vs_validation.py                      # plastics, defaults
+    uv run python scripts/plot_iamc_vs_validation.py --regions EUR,World  # subset of regions
+"""
+
+import argparse
+import math
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from matplotlib.lines import Line2D
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# ID columns of the (wide) IAMC format; everything else is a year column.
+ID_COLUMNS = ["model", "scenario", "region", "variable", "unit"]
+
+# The model's own output is highlighted (black, thicker) to stand out from validation sources.
+MODEL_PREFIX = "REMIND-MFA"
+
+
+def _is_model_output(model: str) -> bool:
+    return str(model).startswith(MODEL_PREFIX)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--material", default="plastics", help="Material model (default: plastics)."
+    )
+    parser.add_argument(
+        "--iamc",
+        default=None,
+        help="Model IAMC .xlsx (default: data/<material>/output/export/iamc/output_iamc.xlsx).",
+    )
+    parser.add_argument(
+        "--validation",
+        default=str(REPO_ROOT.parent / "remind_mfa_data" / "validation" / "validation.mif"),
+        help="Validation .mif file.",
+    )
+    parser.add_argument(
+        "--outdir",
+        default=None,
+        help="Output folder (default: data/<material>/output/export/iamc/validation_plots).",
+    )
+    parser.add_argument("--regions", default=None, help="Comma-separated regions to keep.")
+    parser.add_argument("--scenarios", default=None, help="Comma-separated scenarios to keep.")
+    parser.add_argument("--variables", default=None, help="Comma-separated variables to keep.")
+    parser.add_argument("--ncols", type=int, default=4, help="Subplot columns (default: 4).")
+    parser.add_argument("--show", action="store_true", help="Also display the figures.")
+    return parser.parse_args()
+
+
+def _melt_to_long(df: pd.DataFrame) -> pd.DataFrame:
+    """Convert a wide IAMC DataFrame (lower-cased id columns) to tidy long format."""
+    year_cols = [c for c in df.columns if c not in ID_COLUMNS]
+    long = df.melt(id_vars=ID_COLUMNS, value_vars=year_cols, var_name="year", value_name="value")
+    long["year"] = pd.to_numeric(long["year"], errors="coerce").astype("Int64")
+    long["value"] = pd.to_numeric(long["value"], errors="coerce")
+    long = long.dropna(subset=["year", "value"])
+    long["year"] = long["year"].astype(int)
+    return long
+
+
+def load_model_iamc(path: Path) -> pd.DataFrame:
+    """Load the model IAMC Excel export into tidy long format."""
+    df = pd.read_excel(path, sheet_name="data")
+    df.columns = [str(c).lower() if str(c).lower() in ID_COLUMNS else str(c) for c in df.columns]
+    return _melt_to_long(df)
+
+
+def load_validation(path: Path) -> pd.DataFrame:
+    """Load the validation .mif (semicolon-separated, trailing ';', 'N/A' missing) into long format."""
+    df = pd.read_csv(path, sep=";", na_values=["N/A"])
+    df = df.loc[:, [c for c in df.columns if not str(c).startswith("Unnamed")]]
+    df.columns = [str(c).lower() if str(c).lower() in ID_COLUMNS else str(c) for c in df.columns]
+    return _melt_to_long(df)
+
+
+def build_style_maps(df: pd.DataFrame) -> tuple[dict, dict]:
+    """Map each model to a colour and each (model, scenario) to a linestyle.
+
+    Colour distinguishes models; linestyle distinguishes scenarios *within* a model. Because
+    scenarios barely overlap across models, linestyles are reset per model, so only as many
+    distinct linestyles as the largest scenario count of any single model are ever needed.
+    """
+    models = sorted(df["model"].unique())
+    palette = list(plt.get_cmap("tab10").colors)
+    model_color = {m: palette[i % len(palette)] for i, m in enumerate(models)}
+    # Highlight the model's own output in black so it stands out from the validation sources.
+    for m in models:
+        if _is_model_output(m):
+            model_color[m] = "black"
+
+    base_styles = ["-", "--", "-.", ":"]
+    dash_styles = [(0, d) for d in [(3, 1, 1, 1), (5, 2), (1, 1), (5, 1, 1, 1, 1, 1), (2, 2, 6, 2)]]
+    linestyles = base_styles + dash_styles
+    combo_style = {}
+    for model in models:
+        scenarios = sorted(df[df["model"] == model]["scenario"].unique())
+        for i, scenario in enumerate(scenarios):
+            combo_style[(model, scenario)] = linestyles[i % len(linestyles)]
+    return model_color, combo_style
+
+
+def _sanitize(name: str) -> str:
+    for ch in "|/\\ :":
+        name = name.replace(ch, "_")
+    while "__" in name:
+        name = name.replace("__", "_")
+    return name.strip("_")
+
+
+def plot_variable(
+    sub: pd.DataFrame,
+    display_name: str,
+    model_color: dict,
+    combo_style: dict,
+    ncols: int,
+    outdir: Path,
+    show: bool,
+) -> None:
+    """Produce one figure (region panels) for a single variable and save it as PNG."""
+    regions = sorted(sub["region"].unique())
+    if "World" in regions:
+        regions = ["World"] + [r for r in regions if r != "World"]
+
+    ncols = min(ncols, len(regions))
+    nrows = math.ceil(len(regions) / ncols)
+    fig, axes = plt.subplots(nrows, ncols, figsize=(4.2 * ncols, 3.2 * nrows), sharex=True)
+    axes = list(axes.flat) if hasattr(axes, "flat") else [axes]
+
+    for ax, region in zip(axes, regions):
+        region_df = sub[sub["region"] == region]
+        for (model, scenario), grp in region_df.groupby(["model", "scenario"]):
+            grp = grp.sort_values("year")
+            ax.plot(
+                grp["year"],
+                grp["value"],
+                color=model_color[model],
+                linestyle=combo_style[(model, scenario)],
+                linewidth=2.4 if _is_model_output(model) else 1.4,
+                zorder=3 if _is_model_output(model) else 2,
+            )
+        ax.set_title(region)
+        ax.grid(True, alpha=0.3)
+    for ax in axes[len(regions) :]:
+        ax.set_visible(False)
+
+    unit = sub["unit"].dropna().unique()
+    unit_str = unit[0] if len(unit) else ""
+    fig.suptitle(f"{display_name}  [{unit_str}]", fontsize=13)
+
+    # One proxy-artist legend per line: colour = model, linestyle = scenario, grouped by model.
+    combos_here = sorted(set(map(tuple, sub[["model", "scenario"]].drop_duplicates().values)))
+    combo_handles = [
+        Line2D(
+            [],
+            [],
+            color=model_color[model],
+            linestyle=combo_style[(model, scenario)],
+            lw=2.4 if _is_model_output(model) else 1.6,
+            label=f"{model} | {scenario}",
+        )
+        for model, scenario in combos_here
+    ]
+    fig.legend(
+        handles=combo_handles,
+        title="Model | Scenario",
+        loc="upper left",
+        bbox_to_anchor=(1.0, 0.98),
+        fontsize=8,
+    )
+    fig.tight_layout(rect=(0, 0, 0.82, 0.96))
+
+    outdir.mkdir(parents=True, exist_ok=True)
+    out_path = outdir / f"{_sanitize(display_name)}.png"
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    print(f"  saved {out_path.relative_to(REPO_ROOT)}")
+    if show:
+        plt.show()
+    plt.close(fig)
+
+
+def main() -> None:
+    args = _parse_args()
+
+    iamc_path = Path(
+        args.iamc
+        or REPO_ROOT / "data" / args.material / "output" / "export" / "iamc" / "output_iamc.xlsx"
+    )
+    outdir = Path(
+        args.outdir
+        or REPO_ROOT / "data" / args.material / "output" / "export" / "iamc" / "validation_plots"
+    )
+
+    model_df = load_model_iamc(iamc_path)
+    validation_df = load_validation(Path(args.validation))
+
+    # Overlapping variables, matched case-insensitively; keep model's original casing for display.
+    model_keys = {v.lower(): v for v in model_df["variable"].unique()}
+    validation_keys = set(validation_df["variable"].str.lower().unique())
+    overlap_keys = sorted(set(model_keys) & validation_keys)
+
+    combined = pd.concat([model_df, validation_df], ignore_index=True)
+    combined["_vkey"] = combined["variable"].str.lower()
+
+    if args.variables:
+        wanted = {v.strip().lower() for v in args.variables.split(",")}
+        overlap_keys = [k for k in overlap_keys if k in wanted]
+    if args.regions:
+        keep = {r.strip() for r in args.regions.split(",")}
+        combined = combined[combined["region"].isin(keep)]
+    if args.scenarios:
+        keep = {s.strip() for s in args.scenarios.split(",")}
+        combined = combined[combined["scenario"].isin(keep)]
+
+    if not overlap_keys:
+        print("No overlapping variables to plot.")
+        return
+
+    model_color, combo_style = build_style_maps(combined)
+
+    print(f"Plotting {len(overlap_keys)} variable(s) to {outdir.relative_to(REPO_ROOT)}:")
+    for key in overlap_keys:
+        sub = combined[combined["_vkey"] == key]
+        if sub.empty:
+            continue
+        plot_variable(sub, model_keys[key], model_color, combo_style, args.ncols, outdir, args.show)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_iamc_vs_validation.py
+++ b/scripts/plot_iamc_vs_validation.py
@@ -1,12 +1,15 @@
 """Plot a material model's IAMC outputs against the curated validation data.
 
-For every variable that appears in both the model IAMC output and the validation ``.mif`` file,
-one PNG is produced: region panels (subplots), one colour per model, one linestyle per scenario.
+For every variable that appears in both the model IAMC output and the validation.mif file,
+one PNG is produced: region panels (subplots), one colour per source (column "model" of the validation.mif),
+one linestyle per scenario.
 
 Usage::
 
     uv run python scripts/plot_iamc_vs_validation.py                      # plastics, defaults
     uv run python scripts/plot_iamc_vs_validation.py --regions EUR,World  # subset of regions
+
+NOTE: This script is un-reviewed vibe-coding.
 """
 
 import argparse


### PR DESCRIPTION
This PR aims to streamline the iamc export of the different material models and to make adding new variables easier.
As much code as possible was moved to common_export.py, now only the mapping of flows to iamc variables is done in the material_export.py. The PR also addresses https://github.com/pik-piam/remind-mfa/issues/82
What do you think? I am happy to hear your feedback :)

TODO
- [ ] create a common .mif with the iamc output from all material models
- [ ] agree on a nomenclature - currently we are using variables from the PRISMA project, however they are quite limited and I have added new ones for plastics. Another option would be to use the CIRCOMOD nomenclature, they have more variables.