### PR TITLE
chore: add basic CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Test on Python ${{ matrix.python-version }} (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.14"
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        enable-cache: true
+        version: "0.11.28"
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install
+      run: uv sync --locked
+
+    #- name: Run tests
+    #  run: uv run pytest


### PR DESCRIPTION
Add a basic CI workflow that at the moment only verifies that the package can be installed successfully. Serves as a base for further expansion: at least adding pytest, but hopefully also actually running the mfa after copying the required input data from the cluster.