### PR TITLE
bugfix: move cement losses behind cement market

### DIFF
--- a/remind_mfa/cement/cement_definition.py
+++ b/remind_mfa/cement/cement_definition.py
@@ -80,10 +80,11 @@ def get_cement_definition(cfg: CementCfg, historic: bool) -> RemindMFADefinition
             fd.FlowDefinition(from_process="market_clinker", to_process="prod_cement", dim_letters=("t", "r")),
             fd.FlowDefinition(from_process="sysenv", to_process="prod_cement", dim_letters=("t", "r")),
             fd.FlowDefinition(from_process="prod_cement", to_process="market_cement", dim_letters=("t", "r")),
-            fd.FlowDefinition(from_process="prod_cement", to_process="sysenv", dim_letters=("t", "r")),  # cement losses
             # cement trade
             fd.FlowDefinition(from_process="market_cement", to_process="exports", dim_letters=("t", "r")),
             fd.FlowDefinition(from_process="imports", to_process="market_cement", dim_letters=("t", "r")),
+            # cement losses during construction
+            fd.FlowDefinition(from_process="market_cement", to_process="sysenv", dim_letters=("t", "r")),
             # product production
             fd.FlowDefinition(from_process="market_cement", to_process="prod_product", dim_letters=("t", "r", "s", "m")),
             fd.FlowDefinition(from_process="sysenv", to_process="prod_product", dim_letters=("t", "r", "s", "m")),
@@ -172,7 +173,7 @@ def get_cement_definition(cfg: CementCfg, historic: bool) -> RemindMFADefinition
         RemindMFAParameterDefinition(name="gdppc", dim_letters=("t", "r", "S"),
                                      description="Historic and projected GDP per capita for each region and model year."),
         RemindMFAParameterDefinition(name="cement_losses", dim_letters=(),
-                                     description="Share of cement lost during cement production."),
+                                     description="Share of cement lost during construction."),
         RemindMFAParameterDefinition(name="clinker_losses", dim_letters=(),
                                      description="Share of clinker lost during clinker production."),
         RemindMFAParameterDefinition(name="cement_ratio", dim_letters=("r", "m",),

--- a/remind_mfa/cement/cement_mfa_system_future.py
+++ b/remind_mfa/cement/cement_mfa_system_future.py
@@ -94,13 +94,15 @@ class StockDrivenCementMFASystem(CommonMFASystem):
 
         # cement production
         flw["prod_cement => market_cement"][...] = (
-            flw["market_cement => prod_product"] + flw["market_cement => sysenv"] + trd["cement"].net_exports
+            flw["market_cement => prod_product"]
+            + flw["market_cement => sysenv"]
+            + trd["cement"].net_exports
         )
         flw["market_clinker => prod_cement"][...] = (
             flw["prod_cement => market_cement"] * prm["clinker_ratio"]
         )
-        flw["sysenv => prod_cement"][...] = (
-            flw["prod_cement => market_cement"] * (1 - prm["clinker_ratio"])
+        flw["sysenv => prod_cement"][...] = flw["prod_cement => market_cement"] * (
+            1 - prm["clinker_ratio"]
         )
 
         # clinker trade

--- a/remind_mfa/cement/cement_mfa_system_future.py
+++ b/remind_mfa/cement/cement_mfa_system_future.py
@@ -76,6 +76,11 @@ class StockDrivenCementMFASystem(CommonMFASystem):
         flw["prod_product => use"][...] = stk["in_use"].inflow
         flw["market_cement => prod_product"][...] = flw["prod_product => use"][{"k": "cement"}]
         flw["sysenv => prod_product"][...] = flw["prod_product => use"][{"k": "non-cement"}]
+        flw["market_cement => sysenv"][...] = (
+            flw["market_cement => prod_product"]
+            * prm["cement_losses"]
+            / (1 - prm["cement_losses"])  # construction losses are relative to total production
+        )
 
         # cement trade
         extrapolator = TradeExtrapolator(
@@ -89,19 +94,14 @@ class StockDrivenCementMFASystem(CommonMFASystem):
 
         # cement production
         flw["prod_cement => market_cement"][...] = (
-            flw["market_cement => prod_product"] + trd["cement"].net_exports
-        )
-        flw["prod_cement => sysenv"][...] = (
-            flw["prod_cement => market_cement"]
-            * prm["cement_losses"]
-            / (1 - prm["cement_losses"])  # losses are relative to total production
+            flw["market_cement => prod_product"] + flw["market_cement => sysenv"] + trd["cement"].net_exports
         )
         flw["market_clinker => prod_cement"][...] = (
-            flw["prod_cement => market_cement"] + flw["prod_cement => sysenv"]
-        ) * prm["clinker_ratio"]
+            flw["prod_cement => market_cement"] * prm["clinker_ratio"]
+        )
         flw["sysenv => prod_cement"][...] = (
-            flw["prod_cement => market_cement"] + flw["prod_cement => sysenv"]
-        ) * (1 - prm["clinker_ratio"])
+            flw["prod_cement => market_cement"] * (1 - prm["clinker_ratio"])
+        )
 
         # clinker trade
         extrapolator = TradeExtrapolator(

--- a/remind_mfa/cement/cement_mfa_system_future.py
+++ b/remind_mfa/cement/cement_mfa_system_future.py
@@ -79,7 +79,7 @@ class StockDrivenCementMFASystem(CommonMFASystem):
         flw["market_cement => sysenv"][...] = (
             flw["market_cement => prod_product"]
             * prm["cement_losses"]
-            / (1 - prm["cement_losses"])  # construction losses are relative to total production
+            / (1 - prm["cement_losses"])  # construction losses are relative to total use
         )
 
         # cement trade

--- a/remind_mfa/cement/cement_mfa_system_future.py
+++ b/remind_mfa/cement/cement_mfa_system_future.py
@@ -79,7 +79,7 @@ class StockDrivenCementMFASystem(CommonMFASystem):
         flw["market_cement => sysenv"][...] = (
             flw["market_cement => prod_product"]
             * prm["cement_losses"]
-            / (1 - prm["cement_losses"])  # construction losses are relative to total use
+            / (1 - prm["cement_losses"])  # construction losses are relative to total cement use
         )
 
         # cement trade


### PR DESCRIPTION
Cement losses refer to share of cement lost during the construction phase. This means the loss must not be applied after production, but rather after the cement market. This PR fixes that.