### PR TITLE
feat: add notebook for process graphs

### DIFF
--- a/notebooks/process_graphs.py
+++ b/notebooks/process_graphs.py
@@ -1,0 +1,33 @@
+import marimo
+
+__generated_with = "0.23.15"
+app = marimo.App()
+
+
+@app.cell
+def _():
+    import dotenv
+    import marimo as mo
+    from flodym.export import GraphvizProcessGraphPlotter
+
+    from run_remind_mfa import init_model, read_model_config
+
+    dotenv.load_dotenv()
+
+    graphs = []
+    for historic in [True, False]:
+        graphs.append(mo.md(f"# MFA {'Historic' if historic else 'Future'}"))
+        for model_name in ["steel", "cement", "plastics"]:
+            model_config = read_model_config(f"config/{model_name}.yml")
+            model = init_model(cfg=model_config)
+            mfa = model.make_mfa(historic=historic)
+            dot = GraphvizProcessGraphPlotter(mfa=mfa, rankdir="LR").plot()
+            graphs.append(mo.md(f"## {model_name.capitalize()}"))
+            graphs.append(dot)
+
+    mo.vstack(graphs)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/notebooks/process_graphs.py
+++ b/notebooks/process_graphs.py
@@ -18,7 +18,7 @@ def _():
     for historic in [True, False]:
         graphs.append(mo.md(f"# MFA {'Historic' if historic else 'Future'}"))
         for model_name in ["steel", "cement", "plastics"]:
-            model_config = read_model_config(f"config/{model_name}.yml")
+            model_config = read_model_config(f"../config/{model_name}.yml")
             model = init_model(cfg=model_config)
             mfa = model.make_mfa(historic=historic)
             dot = GraphvizProcessGraphPlotter(mfa=mfa, rankdir="LR").plot()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ docs = [
 ]
 dev = [
     "black>=25.1.0",
-    "ipykernel>=6.29.5",
+    "graphviz>=0.21",
+    "marimo>=0.23.14",
     "nbformat>=5.10.4",
     "questionary>=2.0.1",
     { include-group = "docs" },

--- a/remind_mfa/common/scenarios.py
+++ b/remind_mfa/common/scenarios.py
@@ -13,7 +13,6 @@ from remind_mfa.common.common_definition import (
 )
 from remind_mfa.common.helpers import ModelNames, RemindMFABaseModel
 
-
 # Declares the numpy dtype of each `extra:` column on an extrapolation parameter.
 # Strings need a fixed-width dtype: plain `str` would allocate single characters only.
 EXTRA_DTYPES = {"year": float, "type": "<U32"}


### PR DESCRIPTION
Adds a small notebook that generates all the process graphs for all models (for future + historic).

Needs https://github.com/pik-piam/flodym/pull/180.