### PR TITLE
feat: visualize plastics production

### DIFF
--- a/config/plastics.yml
+++ b/config/plastics.yml
@@ -54,6 +54,8 @@ visualization:
       exclude_flows: [ ]
   sector_splits:
     do_visualize: True
+  material_splits:
+    do_visualize: True
   flows:
     do_visualize: False
 

--- a/remind_mfa/common/scenarios.py
+++ b/remind_mfa/common/scenarios.py
@@ -13,7 +13,6 @@ from remind_mfa.common.common_definition import (
 )
 from remind_mfa.common.helpers import ModelNames, RemindMFABaseModel
 
-
 # Declares the numpy dtype of each `extra:` column on an extrapolation parameter.
 # Strings need a fixed-width dtype: plain `str` would allocate single characters only.
 EXTRA_DTYPES = {"year": float, "type": "<U32"}

--- a/remind_mfa/plastics/plastics_config.py
+++ b/remind_mfa/plastics/plastics_config.py
@@ -4,6 +4,8 @@ from remind_mfa.common.common_config import CommonCfg, VisualizationCfg, BaseVis
 class PlasticsVisualizationCfg(VisualizationCfg):
     flows: BaseVisualizationCfg
     """Visualization configuration for flows."""
+    material_splits: BaseVisualizationCfg
+    """Visualization configuration for material splits in consumption."""
 
 
 class PlasticsCfg(CommonCfg):

--- a/remind_mfa/plastics/plastics_visualization.py
+++ b/remind_mfa/plastics/plastics_visualization.py
@@ -25,14 +25,16 @@ class PlasticsVisualizer(CommonVisualizer):
                 regional=False,
             )
 
-        if self.cfg.consumption.do_visualize:
-            self.compare_demand(mfa=model.future_mfa)
+        if self.cfg.material_splits.do_visualize:
             self.visualize_material_splits(mfa=model.future_mfa)
+
+        if self.cfg.production.do_visualize:
+            self.visualize_production(mfa=model.future_mfa, regional=True)
+            self.visualize_production(mfa=model.future_mfa, regional=False)
 
         if self.cfg.extrapolation.do_visualize:
             self.visualize_extrapolation(model=model, subplot_dim="Good", linecolor_dim="Region")
             self.visualize_extrapolation(model=model, subplot_dim="Region", linecolor_dim="Good")
-            self.visualize_extrapolation_functions(model=model, stock_handler=model.stock_handler)
 
         if self.cfg.flows.do_visualize:
             self.visualize_fdarr_stacked(
@@ -113,6 +115,10 @@ class PlasticsVisualizer(CommonVisualizer):
             per_capita=per_capita,
             regional=True,
         )
+
+    def visualize_production(self, mfa: fd.MFASystem, regional=True):
+        production = mfa.flows["polymerization => primary_market"] + mfa.flows["reclmech => primary_market"]
+        self.visualize_fdarr(mfa=mfa, flow=production, name="Plastics production", regional=regional)
 
     def compare_demand(self, mfa: fd.MFASystem):
         df = pd.read_csv("data/plastics/input/validation.csv", sep=";")

--- a/remind_mfa/plastics/plastics_visualization.py
+++ b/remind_mfa/plastics/plastics_visualization.py
@@ -117,8 +117,12 @@ class PlasticsVisualizer(CommonVisualizer):
         )
 
     def visualize_production(self, mfa: fd.MFASystem, regional=True):
-        production = mfa.flows["polymerization => primary_market"] + mfa.flows["reclmech => primary_market"]
-        self.visualize_fdarr(mfa=mfa, flow=production, name="Plastics production", regional=regional)
+        production = (
+            mfa.flows["polymerization => primary_market"] + mfa.flows["reclmech => primary_market"]
+        )
+        self.visualize_fdarr(
+            mfa=mfa, flow=production, name="Plastics production", regional=regional
+        )
 
     def compare_demand(self, mfa: fd.MFASystem):
         df = pd.read_csv("data/plastics/input/validation.csv", sep=";")


### PR DESCRIPTION
- add function to visualize plastics production
- remove compare_demand plot (now replaced by validation.mif plotting script)
- add switch for visualizing material splits in consumption (previously governed by consumption switch)