### PR TITLE
feat: add cement comparison with mrindustry

### DIFF
--- a/notebooks/compare_mrindustry_mfa.py
+++ b/notebooks/compare_mrindustry_mfa.py
@@ -53,10 +53,7 @@ def _(Path, load_dotenv, mo, os):
 def _(Path, archive_picker, io, mo, pd, tarfile):
     archive_path = Path(archive_picker.value)
 
-
-    def read_cs4r_from_archive(
-        archive: Path, filename: str, columns: list[str]
-    ) -> pd.DataFrame:
+    def read_cs4r_from_archive(archive: Path, filename: str, columns: list[str]) -> pd.DataFrame:
         with tarfile.open(archive, "r:gz") as tar:
             filename = f"./{filename}" if not filename.startswith("./") else filename
             try:
@@ -69,7 +66,6 @@ def _(Path, archive_picker, io, mo, pd, tarfile):
                 )
             text = io.TextIOWrapper(stream, encoding="utf-8")
             return pd.read_csv(text, comment="*", header=None, names=columns)
-
 
     remind_fedemand_industry = read_cs4r_from_archive(
         archive_path,
@@ -127,9 +123,7 @@ def _(archive_path, mo, read_cs4r_from_archive):
 def _(pd, repo_root):
     mfa_steel_dir = repo_root / "data/steel/output/export/mrindustry"
     mfa_steel_production = pd.read_csv(mfa_steel_dir / "steel_production_total.csv")
-    mfa_steel_production_secondary = pd.read_csv(
-        mfa_steel_dir / "steel_production_secondary.csv"
-    )
+    mfa_steel_production_secondary = pd.read_csv(mfa_steel_dir / "steel_production_secondary.csv")
     mfa_steel_scrap = pd.read_csv(mfa_steel_dir / "steel_scrap.csv")
 
     mfa_steel = (
@@ -179,9 +173,7 @@ def _(mfa_cement, mfa_steel, remind_fedemand_industry):
 
 @app.cell
 def _(mo, remind_fedemand_industry, remind_regions):
-    remind_scenarios = sorted(
-        set(remind_fedemand_industry.reset_index()["Scenario"].unique())
-    )
+    remind_scenarios = sorted(set(remind_fedemand_industry.reset_index()["Scenario"].unique()))
     scenario_picker = mo.ui.dropdown(
         options=remind_scenarios,
         value="SSP2" if "SSP2" in remind_scenarios else remind_scenarios[0],
@@ -220,9 +212,9 @@ def _(
     remind_steel["ue_steel_total"] = (
         remind_steel["ue_steel_primary"] + remind_steel["ue_steel_secondary"]
     )
-    remind_steel["steel_secondary_share_calc"] = remind_steel[
-        "ue_steel_secondary"
-    ] / remind_steel["ue_steel_total"].where(remind_steel["ue_steel_total"] != 0)
+    remind_steel["steel_secondary_share_calc"] = remind_steel["ue_steel_secondary"] / remind_steel[
+        "ue_steel_total"
+    ].where(remind_steel["ue_steel_total"] != 0)
 
     mfa_steel_region = mfa_steel.query("Region == @region").drop(columns="Region")
     comparison_steel = (
@@ -349,9 +341,9 @@ def _(
             }
         )
     )
-    cement_comparison = remind_cement.merge(
-        mfa_cement_region, on="Time", how="outer"
-    ).sort_values("Time")
+    cement_comparison = remind_cement.merge(mfa_cement_region, on="Time", how="outer").sort_values(
+        "Time"
+    )
     cement_comparison
     return (cement_comparison,)
 

--- a/notebooks/compare_mrindustry_mfa.py
+++ b/notebooks/compare_mrindustry_mfa.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.23.15"
+__generated_with = "0.23.16"
 app = marimo.App(width="medium")
 
 
@@ -53,7 +53,10 @@ def _(Path, load_dotenv, mo, os):
 def _(Path, archive_picker, io, mo, pd, tarfile):
     archive_path = Path(archive_picker.value)
 
-    def read_cs4r_from_archive(archive: Path, filename: str, columns: list[str]) -> pd.DataFrame:
+
+    def read_cs4r_from_archive(
+        archive: Path, filename: str, columns: list[str]
+    ) -> pd.DataFrame:
         with tarfile.open(archive, "r:gz") as tar:
             filename = f"./{filename}" if not filename.startswith("./") else filename
             try:
@@ -66,6 +69,7 @@ def _(Path, archive_picker, io, mo, pd, tarfile):
                 )
             text = io.TextIOWrapper(stream, encoding="utf-8")
             return pd.read_csv(text, comment="*", header=None, names=columns)
+
 
     remind_fedemand_industry = read_cs4r_from_archive(
         archive_path,
@@ -123,7 +127,9 @@ def _(archive_path, mo, read_cs4r_from_archive):
 def _(pd, repo_root):
     mfa_steel_dir = repo_root / "data/steel/output/export/mrindustry"
     mfa_steel_production = pd.read_csv(mfa_steel_dir / "steel_production_total.csv")
-    mfa_steel_production_secondary = pd.read_csv(mfa_steel_dir / "steel_production_secondary.csv")
+    mfa_steel_production_secondary = pd.read_csv(
+        mfa_steel_dir / "steel_production_secondary.csv"
+    )
     mfa_steel_scrap = pd.read_csv(mfa_steel_dir / "steel_scrap.csv")
 
     mfa_steel = (
@@ -173,7 +179,9 @@ def _(mfa_cement, mfa_steel, remind_fedemand_industry):
 
 @app.cell
 def _(mo, remind_fedemand_industry, remind_regions):
-    remind_scenarios = sorted(set(remind_fedemand_industry.reset_index()["Scenario"].unique()))
+    remind_scenarios = sorted(
+        set(remind_fedemand_industry.reset_index()["Scenario"].unique())
+    )
     scenario_picker = mo.ui.dropdown(
         options=remind_scenarios,
         value="SSP2" if "SSP2" in remind_scenarios else remind_scenarios[0],
@@ -196,16 +204,25 @@ def _(region_picker, scenario_picker):
 
 
 @app.cell
-def _(mfa_steel, pd, remind_fedemand_industry, remind_secondary_share):
+def _(
+    mfa_steel,
+    pd,
+    region,
+    remind_fedemand_industry,
+    remind_secondary_share,
+    scenario,
+):
+    region
+    scenario  # Explicit reference so that marimo knows that these variables are used in the query below and can trigger a re-run when they change.
     remind_steel = pd.concat([remind_fedemand_industry, remind_secondary_share]).query(
         "Scenario == @scenario and Region == @region"
     )
     remind_steel["ue_steel_total"] = (
         remind_steel["ue_steel_primary"] + remind_steel["ue_steel_secondary"]
     )
-    remind_steel["steel_secondary_share_calc"] = remind_steel["ue_steel_secondary"] / remind_steel[
-        "ue_steel_total"
-    ].where(remind_steel["ue_steel_total"] != 0)
+    remind_steel["steel_secondary_share_calc"] = remind_steel[
+        "ue_steel_secondary"
+    ] / remind_steel["ue_steel_total"].where(remind_steel["ue_steel_total"] != 0)
 
     mfa_steel_region = mfa_steel.query("Region == @region").drop(columns="Region")
     comparison_steel = (
@@ -301,7 +318,15 @@ def _(comparison_steel, px, region, scenario):
 
 
 @app.cell
-def _(mfa_cement, remind_clinker_ratio, remind_fedemand_industry):
+def _(
+    mfa_cement,
+    region,
+    remind_clinker_ratio,
+    remind_fedemand_industry,
+    scenario,
+):
+    region
+    scenario  # Explicit reference so that marimo knows that these variables are used in the query below and can trigger a re-run when they change.
     remind_cement = (
         remind_fedemand_industry.reset_index()
         .query("Scenario == @scenario and Region == @region")[["Time", "ue_cement"]]
@@ -324,9 +349,9 @@ def _(mfa_cement, remind_clinker_ratio, remind_fedemand_industry):
             }
         )
     )
-    cement_comparison = remind_cement.merge(mfa_cement_region, on="Time", how="outer").sort_values(
-        "Time"
-    )
+    cement_comparison = remind_cement.merge(
+        mfa_cement_region, on="Time", how="outer"
+    ).sort_values("Time")
     cement_comparison
     return (cement_comparison,)
 

--- a/notebooks/compare_mrindustry_mfa.py
+++ b/notebooks/compare_mrindustry_mfa.py
@@ -53,7 +53,10 @@ def _(Path, load_dotenv, mo, os):
 def _(Path, archive_picker, io, mo, pd, tarfile):
     archive_path = Path(archive_picker.value)
 
-    def read_cs4r_from_archive(archive: Path, filename: str, columns: list[str]) -> pd.DataFrame:
+
+    def read_cs4r_from_archive(
+        archive: Path, filename: str, columns: list[str]
+    ) -> pd.DataFrame:
         with tarfile.open(archive, "r:gz") as tar:
             filename = f"./{filename}" if not filename.startswith("./") else filename
             try:
@@ -66,6 +69,7 @@ def _(Path, archive_picker, io, mo, pd, tarfile):
                 )
             text = io.TextIOWrapper(stream, encoding="utf-8")
             return pd.read_csv(text, comment="*", header=None, names=columns)
+
 
     remind_fedemand_industry = read_cs4r_from_archive(
         archive_path,
@@ -101,11 +105,32 @@ def _(archive_path, mo, read_cs4r_from_archive):
 
 
 @app.cell
+def _(archive_path, mo, read_cs4r_from_archive):
+    remind_clinker_ratio = (
+        read_cs4r_from_archive(
+            archive_path,
+            "p37_clinker-to-cement-ratio.cs4r",
+            ["Time", "Region", "value"],
+        )
+        .rename(columns={"value": "cement_clinker_ratio"})
+        .pivot_table(
+            index=["Time", "Region"],
+            values="cement_clinker_ratio",
+            aggfunc="sum",
+        )
+    )
+    mo.ui.table(remind_clinker_ratio, label="p37_clinker-to-cement-ratio.cs4r")
+    return (remind_clinker_ratio,)
+
+
+@app.cell
 def _(pd, repo_root):
-    mfa_dir = repo_root / "data/steel/output/export/mrindustry"
-    mfa_steel_production = pd.read_csv(mfa_dir / "steel_production_total.csv")
-    mfa_steel_production_secondary = pd.read_csv(mfa_dir / "steel_production_secondary.csv")
-    mfa_steel_scrap = pd.read_csv(mfa_dir / "steel_scrap.csv")
+    mfa_steel_dir = repo_root / "data/steel/output/export/mrindustry"
+    mfa_steel_production = pd.read_csv(mfa_steel_dir / "steel_production_total.csv")
+    mfa_steel_production_secondary = pd.read_csv(
+        mfa_steel_dir / "steel_production_secondary.csv"
+    )
+    mfa_steel_scrap = pd.read_csv(mfa_steel_dir / "steel_scrap.csv")
 
     mfa_steel = (
         mfa_steel_scrap.groupby(["Time", "Region"], as_index=False)["steel_scrap"]
@@ -121,20 +146,42 @@ def _(pd, repo_root):
 
 
 @app.cell
-def _(mfa_steel, remind_fedemand_industry):
+def _(pd, repo_root):
+    mfa_cement_dir = repo_root / "data/cement/output/export/mrindustry"
+    mfa_cement_production = pd.read_csv(mfa_cement_dir / "cement_production.csv")
+    mfa_cement_clinker_ratio = pd.read_csv(mfa_cement_dir / "cement_clinker_ratio.csv")
+
+    mfa_cement = mfa_cement_production.merge(
+        mfa_cement_clinker_ratio, on=["Time", "Region"], how="outer"
+    )
+    mfa_cement["cement_production"] = mfa_cement["cement_production"] / 1e9
+    return (mfa_cement,)
+
+
+@app.cell
+def _(mfa_cement, mfa_steel, remind_fedemand_industry):
     remind_regions = sorted(remind_fedemand_industry.reset_index()["Region"].unique())
-    mfa_regions = sorted(mfa_steel["Region"].unique())
-    regions_diff = set(remind_regions) - set(mfa_regions)
-    if regions_diff:
+    missing_mfa_regions = {
+        "cement": set(remind_regions) - set(mfa_cement["Region"].unique()),
+        "steel": set(remind_regions) - set(mfa_steel["Region"].unique()),
+    }
+    missing_mfa_regions = {
+        material: regions for material, regions in missing_mfa_regions.items() if regions
+    }
+    if missing_mfa_regions:
         raise ValueError(
-            f"Regions in REMIND archive not found in MFA export: {regions_diff}. Make sure that the MFA uses the same region mapping as REMIND."
+            "Regions in REMIND archive not found in MFA exports: "
+            f"{missing_mfa_regions}. Make sure that the MFAs use the same region "
+            "mapping as REMIND."
         )
     return (remind_regions,)
 
 
 @app.cell
 def _(mo, remind_fedemand_industry, remind_regions):
-    remind_scenarios = sorted(set(remind_fedemand_industry.reset_index()["Scenario"].unique()))
+    remind_scenarios = sorted(
+        set(remind_fedemand_industry.reset_index()["Scenario"].unique())
+    )
     scenario_picker = mo.ui.dropdown(
         options=remind_scenarios,
         value="SSP2" if "SSP2" in remind_scenarios else remind_scenarios[0],
@@ -150,29 +197,31 @@ def _(mo, remind_fedemand_industry, remind_regions):
 
 
 @app.cell
-def _(
-    mfa_steel,
-    pd,
-    region_picker,
-    remind_fedemand_industry,
-    remind_secondary_share,
-    scenario_picker,
-):
+def _(region_picker, scenario_picker):
     scenario = scenario_picker.value
     region = region_picker.value
+    return region, scenario
+
+
+@app.cell
+def _(mfa_steel, pd, remind_fedemand_industry, remind_secondary_share):
     remind_steel = pd.concat([remind_fedemand_industry, remind_secondary_share]).query(
         "Scenario == @scenario and Region == @region"
     )
     remind_steel["ue_steel_total"] = (
         remind_steel["ue_steel_primary"] + remind_steel["ue_steel_secondary"]
     )
-    remind_steel["steel_secondary_share_calc"] = remind_steel["ue_steel_secondary"] / remind_steel[
-        "ue_steel_total"
-    ].where(remind_steel["ue_steel_total"] != 0)
+    remind_steel["steel_secondary_share_calc"] = remind_steel[
+        "ue_steel_secondary"
+    ] / remind_steel["ue_steel_total"].where(remind_steel["ue_steel_total"] != 0)
 
-    mfa_region_export = mfa_steel.query("Region == @region").drop(columns="Region")
-    comparison = (
-        remind_steel.merge(mfa_region_export, on="Time", how="outer").sort_values("Time")
+    mfa_steel_region = mfa_steel.query("Region == @region").drop(columns="Region")
+    comparison_steel = (
+        remind_steel.merge(
+            mfa_steel_region,
+            on="Time",
+            how="outer",
+        ).sort_values("Time")
     )[
         [
             "Time",
@@ -195,15 +244,15 @@ def _(
             "steel_production_secondary": "mfa_steel_production_secondary",
         }
     )
-    comparison
-    return comparison, region, scenario
+    comparison_steel
+    return (comparison_steel,)
 
 
 @app.cell
-def _(comparison, px, region, scenario):
+def _(comparison_steel, px, region, scenario):
     # TODO: plotly doesn't want to add lines for the remind steel production before 2100 (probably because of different year resolution)
     px.line(
-        comparison,
+        comparison_steel,
         x="Time",
         y=[
             "mfa_steel_production_total",
@@ -216,9 +265,9 @@ def _(comparison, px, region, scenario):
 
 
 @app.cell
-def _(comparison, px, region, scenario):
+def _(comparison_steel, px, region, scenario):
     px.line(
-        comparison,
+        comparison_steel,
         x="Time",
         y=[
             "mfa_steel_production_secondary",
@@ -231,9 +280,9 @@ def _(comparison, px, region, scenario):
 
 
 @app.cell
-def _(comparison, px, region, scenario):
+def _(comparison_steel, px, region, scenario):
     px.line(
-        comparison,
+        comparison_steel,
         x="Time",
         y=[
             "remind_secondary_share",
@@ -246,14 +295,75 @@ def _(comparison, px, region, scenario):
 
 
 @app.cell
-def _(comparison, px, region, scenario):
+def _(comparison_steel, px, region, scenario):
     px.line(
-        comparison,
+        comparison_steel,
         x="Time",
         y=[
             "mfa_steel_scrap",
         ],
         title=f"Steel scrap for {scenario} ({region})",
+        markers=True,
+    )
+    return
+
+
+@app.cell
+def _(mfa_cement, remind_clinker_ratio, remind_fedemand_industry):
+    remind_cement = (
+        remind_fedemand_industry.reset_index()
+        .query("Scenario == @scenario and Region == @region")[["Time", "ue_cement"]]
+        .merge(
+            remind_clinker_ratio.reset_index()
+            .query("Region == @region")[["Time", "cement_clinker_ratio"]]
+            .rename(columns={"cement_clinker_ratio": "remind_cement_clinker_ratio"}),
+            on="Time",
+            how="outer",
+        )
+        .rename(columns={"ue_cement": "remind_cement_production"})
+    )
+    mfa_cement_region = (
+        mfa_cement.query("Region == @region")
+        .drop(columns="Region")
+        .rename(
+            columns={
+                "cement_production": "mfa_cement_production",
+                "cement_clinker_ratio": "mfa_cement_clinker_ratio",
+            }
+        )
+    )
+    cement_comparison = remind_cement.merge(
+        mfa_cement_region, on="Time", how="outer"
+    ).sort_values("Time")
+    cement_comparison
+    return (cement_comparison,)
+
+
+@app.cell
+def _(cement_comparison, px, region, scenario):
+    px.line(
+        cement_comparison,
+        x="Time",
+        y=[
+            "mfa_cement_production",
+            "remind_cement_production",
+        ],
+        title=f"Cement production for {scenario} ({region})",
+        markers=True,
+    )
+    return
+
+
+@app.cell
+def _(cement_comparison, px, region, scenario):
+    px.line(
+        cement_comparison,
+        x="Time",
+        y=[
+            "mfa_cement_clinker_ratio",
+            "remind_cement_clinker_ratio",
+        ],
+        title=f"Cement clinker ratio for {scenario} ({region})",
         markers=True,
     )
     return

--- a/notebooks/compare_mrindustry_mfa.py
+++ b/notebooks/compare_mrindustry_mfa.py
@@ -53,10 +53,7 @@ def _(Path, load_dotenv, mo, os):
 def _(Path, archive_picker, io, mo, pd, tarfile):
     archive_path = Path(archive_picker.value)
 
-
-    def read_cs4r_from_archive(
-        archive: Path, filename: str, columns: list[str]
-    ) -> pd.DataFrame:
+    def read_cs4r_from_archive(archive: Path, filename: str, columns: list[str]) -> pd.DataFrame:
         with tarfile.open(archive, "r:gz") as tar:
             filename = f"./{filename}" if not filename.startswith("./") else filename
             try:
@@ -69,7 +66,6 @@ def _(Path, archive_picker, io, mo, pd, tarfile):
                 )
             text = io.TextIOWrapper(stream, encoding="utf-8")
             return pd.read_csv(text, comment="*", header=None, names=columns)
-
 
     remind_fedemand_industry = read_cs4r_from_archive(
         archive_path,
@@ -127,9 +123,7 @@ def _(archive_path, mo, read_cs4r_from_archive):
 def _(pd, repo_root):
     mfa_steel_dir = repo_root / "data/steel/output/export/mrindustry"
     mfa_steel_production = pd.read_csv(mfa_steel_dir / "steel_production_total.csv")
-    mfa_steel_production_secondary = pd.read_csv(
-        mfa_steel_dir / "steel_production_secondary.csv"
-    )
+    mfa_steel_production_secondary = pd.read_csv(mfa_steel_dir / "steel_production_secondary.csv")
     mfa_steel_scrap = pd.read_csv(mfa_steel_dir / "steel_scrap.csv")
 
     mfa_steel = (
@@ -179,9 +173,7 @@ def _(mfa_cement, mfa_steel, remind_fedemand_industry):
 
 @app.cell
 def _(mo, remind_fedemand_industry, remind_regions):
-    remind_scenarios = sorted(
-        set(remind_fedemand_industry.reset_index()["Scenario"].unique())
-    )
+    remind_scenarios = sorted(set(remind_fedemand_industry.reset_index()["Scenario"].unique()))
     scenario_picker = mo.ui.dropdown(
         options=remind_scenarios,
         value="SSP2" if "SSP2" in remind_scenarios else remind_scenarios[0],
@@ -211,9 +203,9 @@ def _(mfa_steel, pd, remind_fedemand_industry, remind_secondary_share):
     remind_steel["ue_steel_total"] = (
         remind_steel["ue_steel_primary"] + remind_steel["ue_steel_secondary"]
     )
-    remind_steel["steel_secondary_share_calc"] = remind_steel[
-        "ue_steel_secondary"
-    ] / remind_steel["ue_steel_total"].where(remind_steel["ue_steel_total"] != 0)
+    remind_steel["steel_secondary_share_calc"] = remind_steel["ue_steel_secondary"] / remind_steel[
+        "ue_steel_total"
+    ].where(remind_steel["ue_steel_total"] != 0)
 
     mfa_steel_region = mfa_steel.query("Region == @region").drop(columns="Region")
     comparison_steel = (
@@ -332,9 +324,9 @@ def _(mfa_cement, remind_clinker_ratio, remind_fedemand_industry):
             }
         )
     )
-    cement_comparison = remind_cement.merge(
-        mfa_cement_region, on="Time", how="outer"
-    ).sort_values("Time")
+    cement_comparison = remind_cement.merge(mfa_cement_region, on="Time", how="outer").sort_values(
+        "Time"
+    )
     cement_comparison
     return (cement_comparison,)
 


### PR DESCRIPTION
Building on top of https://github.com/pik-piam/remind-mfa/pull/163, add a comparison of the mfa cement production (and clinker ratio) with the current data of mrindustry.

Produces graphs such as
<img width="1038" height="540" alt="cement" src="https://github.com/user-attachments/assets/5b3a7037-b295-4760-8834-fe5378e49558" />
