### PR TITLE
feat: extract validation.tgz

### DIFF
--- a/remind_mfa/common/common_data_reader.py
+++ b/remind_mfa/common/common_data_reader.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import tarfile
+import warnings
 from pathlib import Path
 
 import flodym as fd
@@ -17,6 +18,11 @@ class CommonDataReader(fd.CompoundDataReader):
     # Documentation-source files bundled in the tgz that belong in this repo's docs/
     # folder rather than in the input-data folder.
     DOC_SOURCE_FILES = {"mrmfa_sources.bib", "mrmfa_sources.csv"}
+
+    # Suffixes (before the ".tgz") distinguishing the two archive kinds produced by madrat:
+    # the main input-data archive and the (optional) validation-data archive.
+    MFA_SUFFIX = "_mfa"
+    VALIDATION_SUFFIX = "_validationmfa"
 
     def __init__(
         self,
@@ -43,6 +49,10 @@ class CommonDataReader(fd.CompoundDataReader):
         return os.path.join(self.input_data_path, "input_data")
 
     @property
+    def validation_path(self) -> str:
+        return os.path.join(self.input_data_path, "validation")
+
+    @property
     def rev_filename(self) -> str:
         return "rev.txt"
 
@@ -60,6 +70,10 @@ class CommonDataReader(fd.CompoundDataReader):
         # extract tar file if needed
         if self.extraction_needed(self.shared_parameter_path):
             self.extract_tar_file(self.shared_parameter_path)
+
+        # extract the matching validation archive (optional; warns if not found)
+        if self.extraction_needed(self.validation_path):
+            self.extract_validation_tar_file(self.validation_path)
 
         # dimensions
         dimension_files = self.get_dimension_dict(self.shared_parameter_path)
@@ -88,22 +102,22 @@ class CommonDataReader(fd.CompoundDataReader):
         with open(path, "w") as f:
             f.write(value)
 
-    @staticmethod
-    def parse_archive_name(filename: str) -> tuple[str, str]:
+    @classmethod
+    def parse_archive_name(cls, filename: str, suffix: str = MFA_SUFFIX) -> tuple[str, str]:
         stem = os.path.basename(filename)
         if stem.endswith(".tgz"):
             stem = stem[: -len(".tgz")]
 
-        if not stem.startswith("rev") or not stem.endswith("_mfa"):
+        if not stem.startswith("rev") or not stem.endswith(suffix):
             raise ValueError(
-                f"Invalid archive name '{filename}'. Expected format rev<rev>_<regions>_<hash>_mfa.tgz"
+                f"Invalid archive name '{filename}'. Expected format rev<rev>_<regions>_<hash>{suffix}.tgz"
             )
 
-        payload = stem[len("rev") : -len("_mfa")]
+        payload = stem[len("rev") : -len(suffix)]
         parts = payload.split("_")
         if len(parts) < 3:
             raise ValueError(
-                f"Invalid archive name '{filename}'. Expected format rev<rev>_<regions>_<hash>_mfa.tgz"
+                f"Invalid archive name '{filename}'. Expected format rev<rev>_<regions>_<hash>{suffix}.tgz"
             )
 
         rev = "_".join(parts[:-2]).strip()
@@ -125,21 +139,29 @@ class CommonDataReader(fd.CompoundDataReader):
         return current_rev != self.input_data_revision or current_regions != self.region_mapping
 
     @staticmethod
-    def build_target_tgz_pattern(input_data_revision: str, region_mapping: str) -> str:
-        return f"rev{glob.escape(input_data_revision)}_" f"{glob.escape(region_mapping)}_*_mfa.tgz"
-
-    def get_target_tgz_path(self) -> str:
-        search_pattern = self.build_target_tgz_pattern(
-            self.input_data_revision, self.region_mapping
+    def build_target_tgz_pattern(
+        input_data_revision: str, region_mapping: str, suffix: str = MFA_SUFFIX
+    ) -> str:
+        return (
+            f"rev{glob.escape(input_data_revision)}_" f"{glob.escape(region_mapping)}_*{suffix}.tgz"
         )
-        matches = sorted(
+
+    def find_target_tgz_paths(self, suffix: str = MFA_SUFFIX) -> list[str]:
+        """Return all madrat archives matching the configured revision/region and given suffix."""
+        search_pattern = self.build_target_tgz_pattern(
+            self.input_data_revision, self.region_mapping, suffix
+        )
+        return sorted(
             glob.glob(os.path.join(self._input_cfg.resolved_madrat_output_path, search_pattern))
         )
+
+    def get_target_tgz_path(self, suffix: str = MFA_SUFFIX) -> str:
+        matches = self.find_target_tgz_paths(suffix)
         if not matches:
             raise FileNotFoundError(
                 "No matching tgz archive found in "
                 f"{self._input_cfg.resolved_madrat_output_path} for revision={self.input_data_revision}, "
-                f"region_mapping={self.region_mapping}."
+                f"region_mapping={self.region_mapping}, suffix={suffix}."
             )
         if len(matches) > 1:
             raise ValueError(
@@ -164,23 +186,81 @@ class CommonDataReader(fd.CompoundDataReader):
                 "existing directory containing the rev*_mfa.tgz archive."
             )
 
-        tgz_path = self.get_target_tgz_path()
+        tgz_path = self.get_target_tgz_path(self.MFA_SUFFIX)
+        self._extract_and_record(tgz_path, material_parameter_path, route_docs=True)
+
+    def extract_validation_tar_file(self, validation_path: str):
+        """Extracts the validation tgz matching the configured revision/region into ``validation_path``.
+
+        The validation archive is optional: if no archive matching the current input-data
+        revision and region mapping is found, a warning is issued and extraction is skipped
+        (rather than raising, as the main input-data archive does).
+        """
+        try:
+            madrat_output_path = self._input_cfg.resolved_madrat_output_path
+        except ValueError:
+            madrat_output_path = None
+        if not madrat_output_path or not os.path.isdir(madrat_output_path):
+            warnings.warn(
+                "No MADRAT output path available to extract the validation archive "
+                f"(revision={self.input_data_revision}, region_mapping={self.region_mapping}). "
+                "Validation data will not be available.",
+                stacklevel=2,
+            )
+            return
+
+        matches = self.find_target_tgz_paths(self.VALIDATION_SUFFIX)
+        if not matches:
+            warnings.warn(
+                "No validation tgz archive found in "
+                f"'{self._input_cfg.resolved_madrat_output_path}' for revision="
+                f"{self.input_data_revision}, region_mapping={self.region_mapping} "
+                f"(expected a rev*{self.VALIDATION_SUFFIX}.tgz archive). "
+                "Validation data will not be available.",
+                stacklevel=2,
+            )
+            return
+        if len(matches) > 1:
+            raise ValueError(
+                "Multiple matching validation tgz archives found for the selected revision/region "
+                "mapping. Make the selector more specific or remove duplicate archives. Matches: "
+                f"{[os.path.basename(match) for match in matches]}"
+            )
+
+        self._extract_and_record(
+            matches[0], validation_path, route_docs=False, suffix=self.VALIDATION_SUFFIX
+        )
+
+    def _extract_and_record(
+        self,
+        tgz_path: str,
+        target_path: str,
+        route_docs: bool,
+        suffix: str = MFA_SUFFIX,
+    ):
+        """Extract ``tgz_path`` into ``target_path`` and record its rev/regions metadata there.
+
+        If ``route_docs`` is set, documentation-source files (see ``DOC_SOURCE_FILES``) are
+        flattened into this repo's ``docs/`` folder instead of ``target_path``.
+        """
+        os.makedirs(target_path, exist_ok=True)
 
         docs_path = Path(__file__).resolve().parents[2] / "docs"
-        os.makedirs(docs_path, exist_ok=True)
+        if route_docs:
+            os.makedirs(docs_path, exist_ok=True)
 
         with tarfile.open(tgz_path, "r:gz") as tar:
             for member in tar.getmembers():
-                if os.path.basename(member.name) in self.DOC_SOURCE_FILES:
+                if route_docs and os.path.basename(member.name) in self.DOC_SOURCE_FILES:
                     # flatten so the file lands directly as docs/<basename>
                     member.name = os.path.basename(member.name)
                     tar.extract(member, path=docs_path)
                 else:
-                    tar.extract(member, path=material_parameter_path)
+                    tar.extract(member, path=target_path)
 
-        rev, regions = self.parse_archive_name(os.path.basename(tgz_path))
-        self.write_text_file(os.path.join(material_parameter_path, self.rev_filename), rev)
-        self.write_text_file(os.path.join(material_parameter_path, self.regions_filename), regions)
+        rev, regions = self.parse_archive_name(os.path.basename(tgz_path), suffix)
+        self.write_text_file(os.path.join(target_path, self.rev_filename), rev)
+        self.write_text_file(os.path.join(target_path, self.regions_filename), regions)
 
     def validate_parameter_files(self, parameter_files: dict[str, str]):
         """Validate that all expected parameter files for the selected model exist."""


### PR DESCRIPTION
Addresses https://github.com/pik-piam/industry_issues/issues/51.
As the preprocessing-mfa now automatically generates a .tgz with validation data for each input data generation, we can automatically extract this when running the MFA as we do for the input data.
The validation plots can then always read the most recent validation.mif from there.