### PR TITLE
fix: update config handling in madrat archive copy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ git clone https://gitlab.pik-potsdam.de/simson_data/remind_mfa_data.git
 - Set the environment variable `MADRAT_OUTPUTFOLDER` to a folder where the madrat output data should be stored (it can be a relative path), e.g., `export MADRAT_OUTPUTFOLDER=madrat_output`. Alternatively, you can set the environment variable in a `.env` file in the main directory of the repository.
 - If you're not running remind-mfa on the cluster, then copy the madrat output data to the local madrat folder by running
 ```bash
-uv run scripts/copy_madrat_archive.py config/steel.yml <hpc> /p/projects/rd3mod/inputdata/output_1.27
+uv run scripts/copy_madrat_archive.py --config default --config  mrindustry <hpc> /p/projects/rd3mod/inputdata/output
 ```
-where `<hpc>` is the ssh address/alias of the PIK cluster.
+where `<hpc>` is the ssh address/alias of the PIK cluster, e.g., `<Your PIK user name>@hpc.pik-potsdam.de`.
 
 
 ## Questions / Problems

--- a/remind_mfa.py
+++ b/remind_mfa.py
@@ -4,7 +4,8 @@ from typing import Annotated, Literal
 import typer
 from dotenv import load_dotenv
 
-from remind_mfa.common.config_loader import get_config_paths, load_config
+from remind_mfa.cli.helper import prompt_for_config_names
+from remind_mfa.common.config_loader import load_config
 from remind_mfa.common.helpers import ModelNames, init_model
 
 app = typer.Typer()
@@ -45,14 +46,6 @@ def prompt_for_model() -> ModelSelection:
             return ModelNames(value)
         except ValueError:
             typer.echo(f"Invalid model {value!r}. Choose one of: {choices}.", err=True)
-
-
-def prompt_for_config_names() -> list[str]:
-    choices = ", ".join(path.stem for path in get_config_paths())
-    entered_names = typer.prompt(
-        f"Configs (comma-separated, available: {choices})", default="default"
-    )
-    return [name.strip() for name in entered_names.split(",") if name.strip()]
 
 
 @app.command()

--- a/remind_mfa/cli/helper.py
+++ b/remind_mfa/cli/helper.py
@@ -1,0 +1,11 @@
+import typer
+
+from remind_mfa.common.config_loader import get_config_paths
+
+
+def prompt_for_config_names() -> list[str]:
+    choices = ", ".join(path.stem for path in get_config_paths())
+    entered_names = typer.prompt(
+        f"Configs (comma-separated, available: {choices})", default="default"
+    )
+    return [name.strip() for name in entered_names.split(",") if name.strip()]

--- a/remind_mfa/common/config_loader.py
+++ b/remind_mfa/common/config_loader.py
@@ -58,7 +58,7 @@ def _load_config_file(name: str, config_dir: Path = CONFIG_DIR) -> dict:
 
 def load_config(
     config_names: list[str],
-    model: ModelNames,
+    model: ModelNames | None = None,
     config_dir: Path = CONFIG_DIR,
 ) -> dict:
     """Load and merge the specified configuration, and return the resulting, validated model configuration."""
@@ -69,10 +69,12 @@ def load_config(
     model_config: dict = {}
     for layer in layers:
         base_config = _deep_merge(base_config, layer.get("base", {}))
-        model_config = _deep_merge(model_config, layer.get(model.value, {}))
+        if model is not None:
+            model_config = _deep_merge(model_config, layer.get(model.value, {}))
 
     # Merge the model-specific configuration into the base configuration
     config = _deep_merge(base_config, model_config)
-    config["model"] = model.value
-    get_model_class(model).ConfigCls.model_validate(config)
+    if model is not None:
+        config["model"] = model.value
+        get_model_class(model).ConfigCls.model_validate(config)
     return config

--- a/scripts/copy_madrat_archive.py
+++ b/scripts/copy_madrat_archive.py
@@ -1,4 +1,5 @@
 """Copy the selected rev<revision>_<region>_*_mfa.tgz archive from a remote machine into the configured madrat_output_path via scp."""
+
 import shlex
 import subprocess
 from pathlib import Path

--- a/scripts/copy_madrat_archive.py
+++ b/scripts/copy_madrat_archive.py
@@ -1,25 +1,27 @@
 """Copy the selected rev<revision>_<region>_*_mfa.tgz archive from a remote machine into the configured madrat_output_path via scp."""
-
 import shlex
 import subprocess
 from pathlib import Path
+from typing import Annotated
 
 import typer
-import yaml
 from dotenv import load_dotenv
 
+from remind_mfa.cli.helper import prompt_for_config_names
 from remind_mfa.common.common_config import InputCfg
 from remind_mfa.common.common_data_reader import CommonDataReader
+from remind_mfa.common.config_loader import load_config
 
 app = typer.Typer(add_completion=False)
 
 
-def read_input_cfg(config_path: str) -> InputCfg:
-    with open(config_path, "r", encoding="utf-8") as handle:
-        config = yaml.safe_load(handle)
+def read_input_cfg(config_names: list[str]) -> InputCfg:
+    config = load_config(config_names)
 
-    if not isinstance(config, dict) or "input" not in config:
-        raise ValueError(f"Config file '{config_path}' does not contain an 'input' section.")
+    if "input" not in config:
+        raise ValueError(
+            f"Configuration {', '.join(config_names)} does not contain an 'input' section."
+        )
 
     return InputCfg.model_validate(config["input"])
 
@@ -70,20 +72,30 @@ def copy_archive(remote_host: str, remote_archive_path: str, destination_dir: Pa
 
 @app.command()
 def main(
-    config: str = typer.Argument(..., help="Path to a remind-mfa YAML config file."),
     remote_host: str = typer.Argument(
         ..., help="Remote SSH target, for example user@host or an SSH config host alias."
     ),
     remote_dir: str = typer.Argument(
         ..., help="Remote directory that contains the rev*_mfa.tgz archives."
     ),
+    config_names: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--config",
+            help="Configuration name under config/. Repeat to stack configurations.",
+        ),
+    ] = None,
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Print the selected source and destination without running scp."
     ),
 ) -> None:
     """Copy the selected rev<revision>_<region>_*_mfa.tgz archive via scp."""
     load_dotenv()
-    input_cfg = read_input_cfg(config)
+
+    if not config_names:
+        config_names = prompt_for_config_names()
+
+    input_cfg = read_input_cfg(config_names)
     destination_dir = resolve_destination_path(input_cfg)
     pattern = CommonDataReader.build_target_tgz_pattern(
         input_cfg.input_data_revision, input_cfg.region_mapping


### PR DESCRIPTION
I've forgot to update that script in the last big config PR. Now `copy_madrat_archive` behaves the same as `remind_mfa` when it comes to the config.  