### PR TITLE
Improve robustness and stdout readability for country-level runs

### DIFF
--- a/remind_mfa.py
+++ b/remind_mfa.py
@@ -29,7 +29,9 @@ def configure_logger():
                 if i == 0:
                     parts.append(textwrap.fill(line, width=_WIDTH, subsequent_indent=_INDENT))
                 else:
-                    parts.append(textwrap.fill(_INDENT + line, width=_WIDTH, subsequent_indent=_INDENT))
+                    parts.append(
+                        textwrap.fill(_INDENT + line, width=_WIDTH, subsequent_indent=_INDENT)
+                    )
             return "\n".join(parts)
 
     handler = logging.StreamHandler()

--- a/remind_mfa.py
+++ b/remind_mfa.py
@@ -1,4 +1,5 @@
 import logging
+import textwrap
 from typing import Annotated, Literal
 
 import typer
@@ -15,12 +16,29 @@ type ModelSelection = Literal["all"] | ModelNames
 
 
 def configure_logger():
-    logging.basicConfig(
-        format="%(asctime)s %(levelname)-8s %(message)s",
-        level=logging.INFO,
-        datefmt="%Y-%m-%d %H:%M:%S",
-        force=True,
-    )
+    _FMT = "%(asctime)s %(levelname)-8s %(message)s"
+    _DATEFMT = "%Y-%m-%d %H:%M:%S"
+    _WIDTH = 132
+    _INDENT = " " * 29  # len("2026-08-21 12:00:00 INFO     ")
+
+    class _IndentFormatter(logging.Formatter):
+        def format(self, record: logging.LogRecord) -> str:
+            text = super().format(record)
+            parts = []
+            for i, line in enumerate(text.splitlines()):
+                if i == 0:
+                    parts.append(textwrap.fill(line, width=_WIDTH, subsequent_indent=_INDENT))
+                else:
+                    parts.append(textwrap.fill(_INDENT + line, width=_WIDTH, subsequent_indent=_INDENT))
+            return "\n".join(parts)
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(_IndentFormatter(fmt=_FMT, datefmt=_DATEFMT))
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    for h in root.handlers[:]:
+        root.removeHandler(h)
+    root.addHandler(handler)
 
 
 def run_remind_mfa(config_names: list[str], models: list[ModelNames]) -> None:

--- a/remind_mfa/common/common_export.py
+++ b/remind_mfa/common/common_export.py
@@ -9,7 +9,13 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import flodym as fd
 import flodym.export as fde
-import pyam
+
+_root_logger = logging.getLogger()
+_prev_level = _root_logger.level
+_root_logger.setLevel(logging.WARNING)
+import pyam  # noqa: E402
+_root_logger.setLevel(_prev_level)
+del _root_logger, _prev_level
 
 from remind_mfa.common.assumptions_doc import assumptions_df, assumptions_str
 from remind_mfa.common.common_config import CommonCfg, ExportCfg

--- a/remind_mfa/common/common_export.py
+++ b/remind_mfa/common/common_export.py
@@ -14,6 +14,7 @@ _root_logger = logging.getLogger()
 _prev_level = _root_logger.level
 _root_logger.setLevel(logging.WARNING)
 import pyam  # noqa: E402
+
 _root_logger.setLevel(_prev_level)
 del _root_logger, _prev_level
 

--- a/remind_mfa/common/common_mfa_system.py
+++ b/remind_mfa/common/common_mfa_system.py
@@ -138,11 +138,13 @@ class CommonMFASystem(fd.MFASystem):
             ).values
         )
         logging.warning(
-            f"'{trade_name}': historic net exports exceed available domestic supply; "
-            f"scaled down {len(coords)} entries:\n{detail}"
-            f"\nNet exports reduced by up to {max_reduction:.0%} in a single region and year "
-            f"to cap them at domestic supply."
+            f"'{trade_name}' trade: historic net exports exceed available domestic supply; "
+            f"scaled down {len(coords)} entries in {len(by_region)} regions. "
+            f"Net exports reduced by up to {max_reduction:.0%} in a single region and year "
+            f"to cap them at domestic supply. Enable logging.DEBUG to see the affected regions "
+            "and categories."
         )
+        logging.debug(f"'Affected regions and categories:\n{detail}")
 
     def get_historical_use_inflow_by_trade_adjusted_split(
         self,

--- a/remind_mfa/common/common_mfa_system.py
+++ b/remind_mfa/common/common_mfa_system.py
@@ -66,7 +66,7 @@ class CommonMFASystem(fd.MFASystem):
         """
         trade = self.trade_set[trade_name]
         eps = sys.float_info.epsilon
-        tolerance = 100 * self._absolute_float_precision
+        tolerance = 10 * self._absolute_float_precision
         # Compare net exports and supply on the dimensions they share. The trade may be more
         # granular than the supply (e.g. per-good indirect exports vs. total fabrication supply)
         # or coarser (e.g. aggregate scrap exports vs. per-good recovered scrap), so both are
@@ -90,7 +90,9 @@ class CommonMFASystem(fd.MFASystem):
             # keeping their imports (same-good stop-over) untouched; factor in [0, 1]
             export_factor = (net_exports_total - net_export_excess) / net_exports_total.maximum(eps)
             trade.exports[...] = trade.exports - net_exports * (1 - export_factor)
-            trade.balance(to="minimum")
+
+            frozen = net_export_excess.cast_values_to(trade.exports.dims) > 0
+            trade.balance(to="minimum", frozen_items=frozen)
         else:
             logging.warning(
                 f"'{trade_name}': positive-net-export cap did not converge after 50 iterations."

--- a/remind_mfa/common/common_model.py
+++ b/remind_mfa/common/common_model.py
@@ -47,9 +47,11 @@ class CommonModel:
         self.init_export_and_visualization()
 
     def run(self):
+        logging.info("Running historical MFA system...")
         self.historic_mfa = self.make_mfa(historic=True)
         self.historic_mfa.compute()
 
+        logging.info("Extrapolating parameters...")
         self.transfer_historic_parameters()
 
         historic_trade = self.historic_mfa.trade_set
@@ -59,8 +61,10 @@ class CommonModel:
         self.extrapolate_parameters()
         self.check_parameters()
 
+        logging.info("Extrapolating in-use stock...")
         stock_projection = self.get_long_term_stock()
 
+        logging.info("Running future MFA system...")
         self.future_mfa = self.make_mfa(historic=False)
         self.future_mfa.compute(stock_projection, historic_trade)
 

--- a/remind_mfa/common/common_visualization.py
+++ b/remind_mfa/common/common_visualization.py
@@ -137,6 +137,12 @@ class CommonVisualizer(RemindMFABaseModel):
         for dimletter in other_dimletters:
             stock = stock.sum_over(dimletter)
 
+        # Remove stocks below a threshold to avoid plots being dominated by very small regions with bad data.
+        # pop_threshold = 1e6
+        # current_pop = population[{"t": mfa.dims["h"].items[-1]}]
+        # current_pop = current_pop.cast_values_to(stock.dims)
+        # stock.values[current_pop < pop_threshold] = 0
+
         if per_capita:
             stock = stock / population
 

--- a/remind_mfa/common/fit_stocks.py
+++ b/remind_mfa/common/fit_stocks.py
@@ -2,9 +2,13 @@ import flodym as fd
 import numpy as np
 from scipy.optimize import minimize
 from pydantic import model_validator
+from logging import warning
 from remind_mfa.common.helpers import RemindMFABaseModel
 from remind_mfa.common.data_extrapolations import Extrapolation
 
+
+class OptimizationError(Exception):
+    pass
 
 class StockFitter(RemindMFABaseModel):
     historic_stocks_pc: fd.FlodymArray
@@ -12,6 +16,7 @@ class StockFitter(RemindMFABaseModel):
     dims_out: fd.DimensionSet
     penalty_weights: dict
     predictor: np.ndarray
+    current_population: fd.FlodymArray
     _n_hist: int = None
 
     @model_validator(mode="after")
@@ -57,13 +62,20 @@ class StockFitter(RemindMFABaseModel):
             shape=(hdims["r"].len, hdims[self.goods_dim_letter].len, self.extrapolation.n_prms)
         )
         self._n_hist = hdims["h"].len
+        ids_failed = []
         for ig in range(hdims[self.goods_dim_letter].len):
             for ir in range(hdims["r"].len):
-                prms[ir, ig, :] = self.fit_single(
-                    historic=self.historic_stocks_pc.values[:, ir, ig],
-                    predictor=self.predictor[:, ir, ig],
-                    prms_0=self.extrapolation.fit_prms[ig, :],
-                )
+                try:
+                    prms[ir, ig, :] = self.fit_single(
+                            historic=self.historic_stocks_pc.values[:, ir, ig],
+                            predictor=self.predictor[:, ir, ig],
+                            prms_0=self.extrapolation.fit_prms[ig, :],
+                        )
+                except OptimizationError:
+                    prms[ir, ig, :] = self.extrapolation.fit_prms[ig, :]
+                    ids_failed.append((ir, ig))
+        if ids_failed:
+            self.warn_failed_optimization(ids_failed)
         values_out = self.extrapolation.func(
             self.predictor[np.newaxis, ...], np.moveaxis(prms[np.newaxis, ...], -1, 0)
         )
@@ -98,17 +110,29 @@ class StockFitter(RemindMFABaseModel):
             penalties.append(self.penalty(historic, predictor, x0, prms_0))
         min_penalty_idx = np.argmin(penalties)
         x0[1] = prms_0[1] + offsets[min_penalty_idx]
-
-        result = minimize(
-            fun=lambda prms: self.penalty(historic, predictor, prms, prms_0),
-            jac=lambda prms: self.jacobian(historic, predictor, prms, prms_0),
-            x0=x0,
-            tol=0.001,
-        )
+        with np.errstate(over="ignore"):  # ignore overflow warnings during optimization
+            result = minimize(
+                fun=lambda prms: self.penalty(historic, predictor, prms, prms_0),
+                jac=lambda prms: self.jacobian(historic, predictor, prms, prms_0),
+                x0=x0,
+                tol=0.001,
+            )
         if result.success:
             return result.x
         else:
-            raise RuntimeError(f"Optimization failed: {result.message}")
+            raise OptimizationError(f"Optimization failed: {result.message}")
+
+    def warn_failed_optimization(self, ids_failed):
+        failed_regions = set(ir for ir, ig in ids_failed)
+        n_failed_regions = len(failed_regions)
+        current_year  = self.historic_stocks_pc.dims["h"].items[-1]
+        current_stocks_pc = self.historic_stocks_pc[{"h": current_year}]
+        current_stocks = (current_stocks_pc * self.current_population).values
+        failed_stocks = current_stocks[ids_failed]
+        share_failed_stocks = failed_stocks.sum() / current_stocks.sum()
+        warning(f"Optimization failed for {len(ids_failed)} good-region combinations in "
+                f"{n_failed_regions} regions, affecting {share_failed_stocks:.2%} of total "
+                "stocks. Using initial parameters for those.")
 
     def penalty(
         self, historic: np.ndarray, predictor: np.ndarray, prms: np.ndarray, prms_0: np.ndarray

--- a/remind_mfa/common/fit_stocks.py
+++ b/remind_mfa/common/fit_stocks.py
@@ -10,6 +10,7 @@ from remind_mfa.common.data_extrapolations import Extrapolation
 class OptimizationError(Exception):
     pass
 
+
 class StockFitter(RemindMFABaseModel):
     historic_stocks_pc: fd.FlodymArray
     extrapolation: Extrapolation
@@ -67,10 +68,10 @@ class StockFitter(RemindMFABaseModel):
             for ir in range(hdims["r"].len):
                 try:
                     prms[ir, ig, :] = self.fit_single(
-                            historic=self.historic_stocks_pc.values[:, ir, ig],
-                            predictor=self.predictor[:, ir, ig],
-                            prms_0=self.extrapolation.fit_prms[ig, :],
-                        )
+                        historic=self.historic_stocks_pc.values[:, ir, ig],
+                        predictor=self.predictor[:, ir, ig],
+                        prms_0=self.extrapolation.fit_prms[ig, :],
+                    )
                 except OptimizationError:
                     prms[ir, ig, :] = self.extrapolation.fit_prms[ig, :]
                     ids_failed.append((ir, ig))
@@ -125,14 +126,16 @@ class StockFitter(RemindMFABaseModel):
     def warn_failed_optimization(self, ids_failed):
         failed_regions = set(ir for ir, ig in ids_failed)
         n_failed_regions = len(failed_regions)
-        current_year  = self.historic_stocks_pc.dims["h"].items[-1]
+        current_year = self.historic_stocks_pc.dims["h"].items[-1]
         current_stocks_pc = self.historic_stocks_pc[{"h": current_year}]
         current_stocks = (current_stocks_pc * self.current_population).values
         failed_stocks = current_stocks[ids_failed]
         share_failed_stocks = failed_stocks.sum() / current_stocks.sum()
-        warning(f"Optimization failed for {len(ids_failed)} good-region combinations in "
-                f"{n_failed_regions} regions, affecting {share_failed_stocks:.2%} of total "
-                "stocks. Using initial parameters for those.")
+        warning(
+            f"Optimization failed for {len(ids_failed)} good-region combinations in "
+            f"{n_failed_regions} regions, affecting {share_failed_stocks:.2%} of total "
+            "stocks. Using initial parameters for those."
+        )
 
     def penalty(
         self, historic: np.ndarray, predictor: np.ndarray, prms: np.ndarray, prms_0: np.ndarray

--- a/remind_mfa/common/stock_extrapolation.py
+++ b/remind_mfa/common/stock_extrapolation.py
@@ -311,6 +311,7 @@ class StockExtrapolation(RemindMFABaseModel):
             predictor=self.single_predictor,
             dims_out=self.dims_out,
             penalty_weights=penalty_weights,
+            current_population=self.pop[{"t": self.dims["h"].items[-1]}],
         )
         self.fitted_regression = stock_fitter.fit()
 

--- a/remind_mfa/common/trade.py
+++ b/remind_mfa/common/trade.py
@@ -37,7 +37,6 @@ class Trade(RemindMFABaseModel):
 
     def balance(self, to: str = "hmean", frozen_items: np.ndarray = None):
 
-
         global_imports = self.imports.sum_over("r")
         global_exports = self.exports.sum_over("r")
 
@@ -47,19 +46,26 @@ class Trade(RemindMFABaseModel):
         scalable_imports = self.imports.copy()
         scalable_exports = self.exports.copy()
         if frozen_items is not None:
-            scalable_imports.values[frozen_items] = 0.
-            scalable_exports.values[frozen_items] = 0.
+            scalable_imports.values[frozen_items] = 0.0
+            scalable_exports.values[frozen_items] = 0.0
         global_unscalable_imports = (self.imports - scalable_imports).sum_over("r")
         global_unscalable_exports = (self.exports - scalable_exports).sum_over("r")
 
-
-        import_factor = (global_reference_trade - global_unscalable_imports) / (global_imports - global_unscalable_imports).maximum(sys.float_info.epsilon)
-        export_factor = (global_reference_trade - global_unscalable_exports) / (global_exports - global_unscalable_exports).maximum(sys.float_info.epsilon)
+        import_factor = (global_reference_trade - global_unscalable_imports) / (
+            global_imports - global_unscalable_imports
+        ).maximum(sys.float_info.epsilon)
+        export_factor = (global_reference_trade - global_unscalable_exports) / (
+            global_exports - global_unscalable_exports
+        ).maximum(sys.float_info.epsilon)
 
         new_imports = self.imports * import_factor
         new_exports = self.exports * export_factor
 
-        scalable_items = np.logical_not(frozen_items) if frozen_items is not None else np.ones_like(self.imports.values, dtype=bool)
+        scalable_items = (
+            np.logical_not(frozen_items)
+            if frozen_items is not None
+            else np.ones_like(self.imports.values, dtype=bool)
+        )
         self.imports.values[scalable_items] = new_imports.values[scalable_items]
         self.exports.values[scalable_items] = new_exports.values[scalable_items]
 

--- a/remind_mfa/common/trade.py
+++ b/remind_mfa/common/trade.py
@@ -35,21 +35,33 @@ class Trade(RemindMFABaseModel):
     def net_exports(self):
         return self.exports - self.imports
 
-    def balance(self, to: str = "hmean"):
+    def balance(self, to: str = "hmean", frozen_items: np.ndarray = None):
+
+
         global_imports = self.imports.sum_over("r")
         global_exports = self.exports.sum_over("r")
 
-        reference_trade = self.get_reference_trade(global_imports, global_exports, to)
-        reference_trade.apply(np.nan_to_num, inplace=True)
+        global_reference_trade = self.get_reference_trade(global_imports, global_exports, to)
+        global_reference_trade.apply(np.nan_to_num, inplace=True)
 
-        import_factor = reference_trade / global_imports.maximum(sys.float_info.epsilon)
-        export_factor = reference_trade / global_exports.maximum(sys.float_info.epsilon)
+        scalable_imports = self.imports.copy()
+        scalable_exports = self.exports.copy()
+        if frozen_items is not None:
+            scalable_imports.values[frozen_items] = 0.
+            scalable_exports.values[frozen_items] = 0.
+        global_unscalable_imports = (self.imports - scalable_imports).sum_over("r")
+        global_unscalable_exports = (self.exports - scalable_exports).sum_over("r")
+
+
+        import_factor = (global_reference_trade - global_unscalable_imports) / (global_imports - global_unscalable_imports).maximum(sys.float_info.epsilon)
+        export_factor = (global_reference_trade - global_unscalable_exports) / (global_exports - global_unscalable_exports).maximum(sys.float_info.epsilon)
 
         new_imports = self.imports * import_factor
         new_exports = self.exports * export_factor
 
-        self.imports[...] = new_imports
-        self.exports[...] = new_exports
+        scalable_items = np.logical_not(frozen_items) if frozen_items is not None else np.ones_like(self.imports.values, dtype=bool)
+        self.imports.values[scalable_items] = new_imports.values[scalable_items]
+        self.exports.values[scalable_items] = new_exports.values[scalable_items]
 
     @staticmethod
     def get_reference_trade(

--- a/remind_mfa/common/trade_extrapolation.py
+++ b/remind_mfa/common/trade_extrapolation.py
@@ -229,7 +229,7 @@ class TradeExtrapolator(RemindMFABaseModel):
             # Clamp to non-negative to avoid divergence.
             # Negative values here should only be in the order of epsilon anyways.
             excess_trade = excess_trade.minimum(self.future_first)
-            self.future_first[...] = (self.future_first - excess_trade)
+            self.future_first[...] = self.future_first - excess_trade
             frozen = excess_trade.cast_values_to(self.future_first.dims) > 0
             self.future_trade.balance(to="minimum", frozen_items=frozen)
 

--- a/remind_mfa/common/trade_extrapolation.py
+++ b/remind_mfa/common/trade_extrapolation.py
@@ -216,17 +216,22 @@ class TradeExtrapolator(RemindMFABaseModel):
         which is why we repeat the process iteratively until the excess is sufficiently small.
         """
         self.future_trade.balance(to="hmean")
-        for i in range(10):
+        tolerance = self.scaler_first
+
+        max_value = self.scaler_first.values.max()
+        epsilon = np.finfo(self.scaler_first.values.dtype).eps
+        tolerance = epsilon * max_value * 100
+        for i in range(50):
             scaler_second = self.scaler_first - self.future_first + self.future_second
             excess_trade = -(scaler_second.minimum(0.0))
-            total_excess = excess_trade.sum_over("r")
-            if np.max(total_excess.values) < 0.1:
+            if excess_trade.values.max() < tolerance:
                 break
-            # Clamp to >= 0: without this, a large excess can drive regional imports negative,
-            # after which balance() divides by a near-zero/negative global total and the result
-            # diverges (or leaves global trade unbalanced).
-            self.future_first[...] = (self.future_first - excess_trade).maximum(0)
-            self.future_trade.balance(to="minimum")
+            # Clamp to non-negative to avoid divergence.
+            # Negative values here should only be in the order of epsilon anyways.
+            excess_trade = excess_trade.minimum(self.future_first)
+            self.future_first[...] = (self.future_first - excess_trade)
+            frozen = excess_trade.cast_values_to(self.future_first.dims) > 0
+            self.future_trade.balance(to="minimum", frozen_items=frozen)
 
         np.testing.assert_array_almost_equal(
             self.future_first.sum_over(

--- a/remind_mfa/common/trade_extrapolation.py
+++ b/remind_mfa/common/trade_extrapolation.py
@@ -226,8 +226,9 @@ class TradeExtrapolator(RemindMFABaseModel):
             excess_trade = -(scaler_second.minimum(0.0))
             if excess_trade.values.max() < tolerance:
                 break
-            # Clamp to non-negative to avoid divergence.
-            # Negative values here should only be in the order of epsilon anyways.
+            # Clamp such that future_first stays non-negative to avoid divergence.
+            # Negative values here only occur if scaler_first or future_second are negative,
+            # e.g. due to previous tolerances,
             excess_trade = excess_trade.minimum(self.future_first)
             self.future_first[...] = self.future_first - excess_trade
             frozen = excess_trade.cast_values_to(self.future_first.dims) > 0

--- a/remind_mfa/plastics/plastics_mfa_system_historic.py
+++ b/remind_mfa/plastics/plastics_mfa_system_historic.py
@@ -73,7 +73,9 @@ class PlasticsMFASystemHistoric(CommonMFASystem):
         )
 
         with np.errstate(divide="ignore"):
-            self.parameters["material_shares_use_inflow"][...] = self.parameters["material_shares_use_inflow"].get_shares_over(("m",))
+            self.parameters["material_shares_use_inflow"][...] = self.parameters[
+                "material_shares_use_inflow"
+            ].get_shares_over(("m",))
         self.parameters["material_shares_use_inflow"].apply(np.nan_to_num, inplace=True)
         # get global good split from historic stock inflow
         self.parameters["global_good_shares_use_inflow"] = fd.Parameter(

--- a/remind_mfa/plastics/plastics_mfa_system_historic.py
+++ b/remind_mfa/plastics/plastics_mfa_system_historic.py
@@ -1,4 +1,5 @@
 import flodym as fd
+import numpy as np
 
 from remind_mfa.plastics.plastics_config import PlasticsCfg
 from remind_mfa.common.common_mfa_system import CommonMFASystem
@@ -16,7 +17,7 @@ class PlasticsMFASystemHistoric(CommonMFASystem):
         self.trade_set.balance(to="maximum")
         self.compute_flows()
         self.compute_historic_stock()
-        self.check_mass_balance()
+        self.check_mass_balance(raise_error=True)
         self.check_flows(raise_error=False)
 
     def compute_flows(self):
@@ -70,6 +71,10 @@ class PlasticsMFASystemHistoric(CommonMFASystem):
             .get_shares_over(("m",))
             .values,
         )
+
+        with np.errstate(divide="ignore"):
+            self.parameters["material_shares_use_inflow"][...] = self.parameters["material_shares_use_inflow"].get_shares_over(("m",))
+        self.parameters["material_shares_use_inflow"].apply(np.nan_to_num, inplace=True)
         # get global good split from historic stock inflow
         self.parameters["global_good_shares_use_inflow"] = fd.Parameter(
             dims=self.dims["h", "g"],

--- a/remind_mfa/steel/steel_model.py
+++ b/remind_mfa/steel/steel_model.py
@@ -135,7 +135,7 @@ class SteelModel(CommonModel):
         self.parameters["sector_split"] = fd.Parameter(dims=target_dims, name="sector_split")
         sector_split_1 = fd.Parameter(dims=target_dims)
         sector_split_2 = fd.Parameter(dims=target_dims)
-        log_gdppc = self.parameters["gdppc"].apply(np.log)
+        log_gdppc = self.parameters["gdppc"].maximum(self.parameters["secsplit_gdppc_low"]).apply(np.log)
         log_gdppc_low = self.parameters["secsplit_gdppc_low"].apply(np.log)
         log_gdppc_high = self.parameters["secsplit_gdppc_high"].apply(np.log)
         add_assumption_doc(

--- a/remind_mfa/steel/steel_model.py
+++ b/remind_mfa/steel/steel_model.py
@@ -135,7 +135,9 @@ class SteelModel(CommonModel):
         self.parameters["sector_split"] = fd.Parameter(dims=target_dims, name="sector_split")
         sector_split_1 = fd.Parameter(dims=target_dims)
         sector_split_2 = fd.Parameter(dims=target_dims)
-        log_gdppc = self.parameters["gdppc"].maximum(self.parameters["secsplit_gdppc_low"]).apply(np.log)
+        log_gdppc = (
+            self.parameters["gdppc"].maximum(self.parameters["secsplit_gdppc_low"]).apply(np.log)
+        )
         log_gdppc_low = self.parameters["secsplit_gdppc_low"].apply(np.log)
         log_gdppc_high = self.parameters["secsplit_gdppc_high"].apply(np.log)
         add_assumption_doc(


### PR DESCRIPTION
## Current status when attempting to run iso249:

- **Steel** now works flawlessly 
- **Plastics** runs **if** I change mass balance check behaviour in the historical MFA to "warn" instead of "error". It warns about negative production parameter and lots of negative flows, though. A lot of spikes in the plots, too, always the same regions. Probably needs further attention. 
- **Cement** fails on scenario parameters with H12 region codes. This type of problem will become quite common in the future, so I made it an [issue](https://github.com/pik-piam/industry_issues/issues/58). TBD in the JF. 

## What has changed: 

### Robust stock extrapolation 

If the minimization in the stock extrapolation algorithm fails for some region/good combination, make it fall back to the global regression.
Throw a warning which synthesizes the share of stocks that are affected by this. 

### Changed trade scaling 

When we scale down imports or exports to meet regional mass balance requirements, the global trade balancing now freezes these region/other id trades, because otherwise the global scaling would make them fail the regional mass balance instantly again. 

(E.g., if we scale down regional exports because net exports exceed local production, then global exports don't match global imports anymore. If we then scale down all imports (as we did so far), then the regional mass balance fails again. Now, we only scale down imports in all other regions instead). 

We still need iterations, but less: The mass balance in some of the other regions might now fail because we scaled down imports there. So the theoretical max number of required iterations is now n_regions, in practice much less, of course. 

I also improved consistency of the tolerances in these iterations. In the future MFA, this avoids some negative flows for me. 

### Logging updates 

- Remove info messages occurring on import of pyam package. TBD: I now changed the logger level befreo and after the pyam import. 
- keep indent for multi-line messages; I introduces a max line width to also achieve this for over-long messages where the terminal introduces line breaks. TBD if you like it. 
- remove some information in warnings, and add a reference to a debug-level message instead, to keep the info concise. 
- Add a few more status messages at major model steps
